### PR TITLE
CI: make image builds resilient + add dynamic version discovery

### DIFF
--- a/.github/workflows/docker-image-dnsmasq.yml
+++ b/.github/workflows/docker-image-dnsmasq.yml
@@ -34,4 +34,4 @@ jobs:
           build-args: WEBPROC_VERSION=0.4.0
           push: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
           tags: ghcr.io/${{ github.repository_owner }}/roll/dnsmasq:latest
-        if: ${{ !env.ACT && github.ref == 'refs/heads/master'}}
+        if: ${{ !env.ACT }}

--- a/.github/workflows/docker-image-dnsmasq.yml
+++ b/.github/workflows/docker-image-dnsmasq.yml
@@ -27,13 +27,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ !env.ACT }}
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-        if: ${{ !env.ACT }}
-
       - uses: docker/build-push-action@v6
         with:
           context: dnsmasq

--- a/.github/workflows/docker-image-dragonflydb.yml
+++ b/.github/workflows/docker-image-dragonflydb.yml
@@ -58,7 +58,7 @@ jobs:
             [ "$(printf '%s\n%s\n' "$MIN" "$v" | sort -V | head -n1)" = "$MIN" ] || continue
             SEL="$SEL $v"
           done
-          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV)
+          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV || true)
           echo "Selected Dragonfly versions: $(echo $SEL | paste -sd' ' -)"
 
           if [ -z "$(echo $SEL | tr -d '[:space:]')" ]; then

--- a/.github/workflows/docker-image-dragonflydb.yml
+++ b/.github/workflows/docker-image-dragonflydb.yml
@@ -107,4 +107,4 @@ jobs:
           build-args: DRAGONFLY_VERSION=${{ env.DRAGONFLY_VERSION }}
           push: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
           tags: ghcr.io/${{ github.repository_owner }}/roll/dragonfly:${{ matrix.version }}
-        if: ${{ !env.ACT && github.ref == 'refs/heads/master'}}
+        if: ${{ !env.ACT }}

--- a/.github/workflows/docker-image-dragonflydb.yml
+++ b/.github/workflows/docker-image-dragonflydb.yml
@@ -1,6 +1,11 @@
 name: Docker Image Dragonfly DB
 on:
   workflow_dispatch:
+    inputs:
+      versions:
+        description: 'Versions (major.minor, comma-separated). Empty = auto-discover.'
+        required: false
+        type: string
   schedule:
     - cron: "0 6 * * *" # 6 AM Daily
   push:
@@ -9,32 +14,70 @@ on:
       - dragonfly/**
       - .github/workflows/*dragonfly*
 
-
 jobs:
-  dragonfly:
-    name: Dragonfly DB
+  # Discover which versions to build: the pinned list is always built and any
+  # upstream major.minor newer than the highest pinned one is added automatically.
+  # The major.minor is resolved to its latest patch (v-prefixed) at build time.
+  # Edit PIN to curate, DENY to exclude, MIN for the floor. See README.
+  discover:
+    name: Discover Dragonfly versions
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.discover.outputs.matrix }}
+      build: ${{ steps.discover.outputs.build }}
+    steps:
+      - name: Discover versions
+        id: discover
+        run: |
+          set -uo pipefail
+          UPSTREAM="docker.dragonflydb.io/dragonflydb/dragonfly"
+          MIN="1.3"                                                              # floor — ignore anything older
+          PIN="1.3 1.4 1.5 1.6 1.7 1.8 1.9 1.10 1.11 1.12 1.13 1.14 1.15 1.16 1.17"  # always built + fallback
+          DENY=""                                                                # never build these
+          OVERRIDE="${{ inputs.versions }}"
 
+          MAXPIN=$(printf '%s\n' $PIN | sort -V | tail -1)
+          if [ -n "${OVERRIDE}" ]; then
+            CAND=$(echo "$OVERRIDE" | tr ', ' '\n' | grep -v '^$' || true)
+          else
+            # Upstream publishes vX.Y.Z tags; reduce to unique major.minor.
+            DISCOVERED=$(docker run --rm gcr.io/go-containerregistry/crane ls "$UPSTREAM" 2>/dev/null \
+              | sed 's/^v//' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | awk -F. '{print $1"."$2}' \
+              | sort -uV | paste -sd' ' - || true)
+            NEWER=""
+            for v in $DISCOVERED; do
+              [ "$v" = "$MAXPIN" ] && continue
+              [ "$(printf '%s\n%s\n' "$MAXPIN" "$v" | sort -V | tail -1)" = "$v" ] && NEWER="$NEWER $v"
+            done
+            CAND="$PIN $NEWER"
+          fi
+
+          SEL=""
+          for v in $CAND; do
+            case " $DENY " in *" $v "*) continue ;; esac
+            [ "$(printf '%s\n%s\n' "$MIN" "$v" | sort -V | head -n1)" = "$MIN" ] || continue
+            SEL="$SEL $v"
+          done
+          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV)
+          echo "Selected Dragonfly versions: $(echo $SEL | paste -sd' ' -)"
+
+          if [ -z "$(echo $SEL | tr -d '[:space:]')" ]; then
+            echo 'matrix={"version":[]}' >> "$GITHUB_OUTPUT"
+            echo 'build=false' >> "$GITHUB_OUTPUT"
+          else
+            MATRIX=$(printf '%s\n' $SEL | jq -R . | jq -cs '{version: .}')
+            echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+            echo 'build=true' >> "$GITHUB_OUTPUT"
+          fi
+
+  dragonfly:
+    name: Dragonfly DB ${{ matrix.version }}
+    needs: discover
+    if: needs.discover.outputs.build == 'true'
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        version:
-          - "1.3"
-          - "1.4"
-          - "1.5"
-          - "1.6"
-          - "1.7"
-          - "1.8"
-          - "1.9"
-          - "1.10"
-          - "1.11"
-          - "1.12"
-          - "1.13"
-          - "1.14"
-          - "1.15"
-          - "1.16"
-          - "1.17"
-
+      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
@@ -46,13 +89,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ !env.ACT }}
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
         if: ${{ !env.ACT }}
 
       - name: Set build-args

--- a/.github/workflows/docker-image-elasticsearch.yml
+++ b/.github/workflows/docker-image-elasticsearch.yml
@@ -1,28 +1,83 @@
 name: Docker Image Elasticsearch
 on:
   workflow_dispatch:
+    inputs:
+      versions:
+        description: 'Versions (major.minor, comma-separated). Empty = auto-discover.'
+        required: false
+        type: string
   schedule:
     - cron: "0 6 * * *" # 6 AM Daily
   push:
     paths:
+      - .trigger
       - elasticsearch/**
       - .github/workflows/docker-image-elasticsearch.yml
 
 jobs:
-  elasticsearch:
-    name: Elasticsearch
+  # Discover which versions to build: the pinned list is always built and any
+  # upstream major.minor newer than the highest pinned one is added automatically.
+  # The major.minor is resolved to its latest patch at build time below.
+  # Edit PIN to curate, DENY to exclude, MIN for the floor. See README.
+  discover:
+    name: Discover Elasticsearch versions
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.discover.outputs.matrix }}
+      build: ${{ steps.discover.outputs.build }}
+    steps:
+      - name: Discover versions
+        id: discover
+        run: |
+          set -uo pipefail
+          UPSTREAM="docker.elastic.co/elasticsearch/elasticsearch"
+          MIN="7.17"                                      # floor — ignore anything older
+          PIN="7.17 8.4 8.6 8.11 8.12 8.13"               # always built + fallback if discovery fails
+          DENY=""                                         # never build these
+          OVERRIDE="${{ inputs.versions }}"
 
+          MAXPIN=$(printf '%s\n' $PIN | sort -V | tail -1)
+          if [ -n "${OVERRIDE}" ]; then
+            CAND=$(echo "$OVERRIDE" | tr ', ' '\n' | grep -v '^$' || true)
+          else
+            # Upstream publishes x.y.z tags; reduce to unique major.minor.
+            DISCOVERED=$(docker run --rm gcr.io/go-containerregistry/crane ls "$UPSTREAM" 2>/dev/null \
+              | sed 's/^v//' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | awk -F. '{print $1"."$2}' \
+              | sort -uV | paste -sd' ' - || true)
+            NEWER=""
+            for v in $DISCOVERED; do
+              [ "$v" = "$MAXPIN" ] && continue
+              [ "$(printf '%s\n%s\n' "$MAXPIN" "$v" | sort -V | tail -1)" = "$v" ] && NEWER="$NEWER $v"
+            done
+            CAND="$PIN $NEWER"
+          fi
+
+          SEL=""
+          for v in $CAND; do
+            case " $DENY " in *" $v "*) continue ;; esac
+            [ "$(printf '%s\n%s\n' "$MIN" "$v" | sort -V | head -n1)" = "$MIN" ] || continue
+            SEL="$SEL $v"
+          done
+          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV)
+          echo "Selected Elasticsearch versions: $(echo $SEL | paste -sd' ' -)"
+
+          if [ -z "$(echo $SEL | tr -d '[:space:]')" ]; then
+            echo 'matrix={"version":[]}' >> "$GITHUB_OUTPUT"
+            echo 'build=false' >> "$GITHUB_OUTPUT"
+          else
+            MATRIX=$(printf '%s\n' $SEL | jq -R . | jq -cs '{version: .}')
+            echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+            echo 'build=true' >> "$GITHUB_OUTPUT"
+          fi
+
+  elasticsearch:
+    name: Elasticsearch ${{ matrix.version }}
+    needs: discover
+    if: needs.discover.outputs.build == 'true'
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        version:
-          - "7.17"
-          - "8.4"
-          - "8.6"
-          - "8.11"
-          - "8.12"
-          - "8.13"
+      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
@@ -34,13 +89,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ !env.ACT }}
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
         if: ${{ !env.ACT }}
 
       - name: Set build-args

--- a/.github/workflows/docker-image-elasticsearch.yml
+++ b/.github/workflows/docker-image-elasticsearch.yml
@@ -58,7 +58,7 @@ jobs:
             [ "$(printf '%s\n%s\n' "$MIN" "$v" | sort -V | head -n1)" = "$MIN" ] || continue
             SEL="$SEL $v"
           done
-          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV)
+          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV || true)
           echo "Selected Elasticsearch versions: $(echo $SEL | paste -sd' ' -)"
 
           if [ -z "$(echo $SEL | tr -d '[:space:]')" ]; then

--- a/.github/workflows/docker-image-magepack.yml
+++ b/.github/workflows/docker-image-magepack.yml
@@ -40,13 +40,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ !env.ACT }}
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-        if: ${{ !env.ACT }}
-
       - uses: docker/build-push-action@v6
         with:
           context: magepack

--- a/.github/workflows/docker-image-mailhog.yml
+++ b/.github/workflows/docker-image-mailhog.yml
@@ -27,13 +27,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ !env.ACT }}
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-        if: ${{ !env.ACT }}
-
       - uses: docker/build-push-action@v6
         with:
           context: mailhog

--- a/.github/workflows/docker-image-mailhog.yml
+++ b/.github/workflows/docker-image-mailhog.yml
@@ -33,4 +33,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
           tags: ghcr.io/${{ github.repository_owner }}/roll/mailhog:latest
-        if: ${{ !env.ACT && github.ref == 'refs/heads/master'}}
+        if: ${{ !env.ACT }}

--- a/.github/workflows/docker-image-mariadb.yml
+++ b/.github/workflows/docker-image-mariadb.yml
@@ -1,6 +1,11 @@
 name: Docker Image MariaDB
 on:
   workflow_dispatch:
+    inputs:
+      versions:
+        description: 'Versions to build (comma-separated). Empty = auto-discover.'
+        required: false
+        type: string
   schedule:
     - cron: "0 6 * * *" # 6 AM Daily
   push:
@@ -10,20 +15,66 @@ on:
       - .github/workflows/*mariadb*
 
 jobs:
-  mariadb:
-    name: MariaDB
+  # Discover which versions to build: the pinned list is always built and any
+  # upstream version newer than the highest pinned one is added automatically.
+  # Edit PIN to curate, DENY to exclude, MIN for the floor. See README.
+  discover:
+    name: Discover MariaDB versions
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.discover.outputs.matrix }}
+      build: ${{ steps.discover.outputs.build }}
+    steps:
+      - name: Discover versions
+        id: discover
+        run: |
+          set -uo pipefail
+          UPSTREAM="mariadb"
+          MIN="10.3"                              # floor — ignore anything older
+          PIN="10.3 10.4 10.6 11.3 11.4"          # always built + fallback if discovery fails
+          DENY=""                                 # never build these
+          OVERRIDE="${{ inputs.versions }}"
 
+          MAXPIN=$(printf '%s\n' $PIN | sort -V | tail -1)
+          if [ -n "${OVERRIDE}" ]; then
+            CAND=$(echo "$OVERRIDE" | tr ', ' '\n' | grep -v '^$' || true)
+          else
+            DISCOVERED=$(docker run --rm gcr.io/go-containerregistry/crane ls "$UPSTREAM" 2>/dev/null \
+              | grep -E '^[0-9]+\.[0-9]+$' | sort -uV | paste -sd' ' - || true)
+            NEWER=""
+            for v in $DISCOVERED; do
+              [ "$v" = "$MAXPIN" ] && continue
+              [ "$(printf '%s\n%s\n' "$MAXPIN" "$v" | sort -V | tail -1)" = "$v" ] && NEWER="$NEWER $v"
+            done
+            CAND="$PIN $NEWER"
+          fi
+
+          SEL=""
+          for v in $CAND; do
+            case " $DENY " in *" $v "*) continue ;; esac
+            [ "$(printf '%s\n%s\n' "$MIN" "$v" | sort -V | head -n1)" = "$MIN" ] || continue
+            SEL="$SEL $v"
+          done
+          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV)
+          echo "Selected MariaDB versions: $(echo $SEL | paste -sd' ' -)"
+
+          if [ -z "$(echo $SEL | tr -d '[:space:]')" ]; then
+            echo 'matrix={"version":[]}' >> "$GITHUB_OUTPUT"
+            echo 'build=false' >> "$GITHUB_OUTPUT"
+          else
+            MATRIX=$(printf '%s\n' $SEL | jq -R . | jq -cs '{version: .}')
+            echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+            echo 'build=true' >> "$GITHUB_OUTPUT"
+          fi
+
+  mariadb:
+    name: MariaDB ${{ matrix.version }}
+    needs: discover
+    if: needs.discover.outputs.build == 'true'
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        version:
-          - "10.3"
-          - "10.4"
-          - "10.6"
-          - "11.3"
-          - "11.4"
-
+      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
@@ -37,18 +88,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ !env.ACT }}
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-        if: ${{ !env.ACT }}
-
       - uses: docker/build-push-action@v6
         with:
           context: mariadb
           platforms: linux/amd64,linux/arm64
-          build-args: MARIADB_VERSION=${{ matrix.version }}${{ matrix.modifier }}
+          build-args: MARIADB_VERSION=${{ matrix.version }}
           push: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
-          tags: ghcr.io/${{ github.repository_owner }}/roll/mariadb:${{ matrix.version }}${{ matrix.modifier }}
+          tags: ghcr.io/${{ github.repository_owner }}/roll/mariadb:${{ matrix.version }}
         if: ${{ !env.ACT && github.ref == 'refs/heads/master'}}

--- a/.github/workflows/docker-image-mariadb.yml
+++ b/.github/workflows/docker-image-mariadb.yml
@@ -95,4 +95,4 @@ jobs:
           build-args: MARIADB_VERSION=${{ matrix.version }}
           push: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
           tags: ghcr.io/${{ github.repository_owner }}/roll/mariadb:${{ matrix.version }}
-        if: ${{ !env.ACT && github.ref == 'refs/heads/master'}}
+        if: ${{ !env.ACT }}

--- a/.github/workflows/docker-image-mariadb.yml
+++ b/.github/workflows/docker-image-mariadb.yml
@@ -55,7 +55,7 @@ jobs:
             [ "$(printf '%s\n%s\n' "$MIN" "$v" | sort -V | head -n1)" = "$MIN" ] || continue
             SEL="$SEL $v"
           done
-          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV)
+          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV || true)
           echo "Selected MariaDB versions: $(echo $SEL | paste -sd' ' -)"
 
           if [ -z "$(echo $SEL | tr -d '[:space:]')" ]; then

--- a/.github/workflows/docker-image-mongo.yml
+++ b/.github/workflows/docker-image-mongo.yml
@@ -55,7 +55,7 @@ jobs:
             [ "$(printf '%s\n%s\n' "$MIN" "$v" | sort -V | head -n1)" = "$MIN" ] || continue
             SEL="$SEL $v"
           done
-          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV)
+          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV || true)
           echo "Selected MongoDB versions: $(echo $SEL | paste -sd' ' -)"
 
           if [ -z "$(echo $SEL | tr -d '[:space:]')" ]; then

--- a/.github/workflows/docker-image-mongo.yml
+++ b/.github/workflows/docker-image-mongo.yml
@@ -1,6 +1,11 @@
-name: Docker Image MangoDB
+name: Docker Image MongoDB
 on:
   workflow_dispatch:
+    inputs:
+      versions:
+        description: 'Versions to build (comma-separated). Empty = auto-discover.'
+        required: false
+        type: string
   schedule:
     - cron: "0 6 * * *" # 6 AM Daily
   push:
@@ -10,18 +15,66 @@ on:
       - .github/workflows/*mongo*
 
 jobs:
-  mongo:
-    name: MongoDB
+  # Discover which versions to build: the pinned list is always built and any
+  # upstream version newer than the highest pinned one is added automatically.
+  # Edit PIN to curate, DENY to exclude, MIN for the floor. See README.
+  discover:
+    name: Discover MongoDB versions
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.discover.outputs.matrix }}
+      build: ${{ steps.discover.outputs.build }}
+    steps:
+      - name: Discover versions
+        id: discover
+        run: |
+          set -uo pipefail
+          UPSTREAM="mongo"
+          MIN="5"                         # floor — ignore anything older
+          PIN="5 6 7"                     # always built + fallback if discovery fails
+          DENY=""                         # never build these
+          OVERRIDE="${{ inputs.versions }}"
 
+          MAXPIN=$(printf '%s\n' $PIN | sort -V | tail -1)
+          if [ -n "${OVERRIDE}" ]; then
+            CAND=$(echo "$OVERRIDE" | tr ', ' '\n' | grep -v '^$' || true)
+          else
+            DISCOVERED=$(docker run --rm gcr.io/go-containerregistry/crane ls "$UPSTREAM" 2>/dev/null \
+              | grep -E '^[0-9]+$' | sort -uV | paste -sd' ' - || true)
+            NEWER=""
+            for v in $DISCOVERED; do
+              [ "$v" = "$MAXPIN" ] && continue
+              [ "$(printf '%s\n%s\n' "$MAXPIN" "$v" | sort -V | tail -1)" = "$v" ] && NEWER="$NEWER $v"
+            done
+            CAND="$PIN $NEWER"
+          fi
+
+          SEL=""
+          for v in $CAND; do
+            case " $DENY " in *" $v "*) continue ;; esac
+            [ "$(printf '%s\n%s\n' "$MIN" "$v" | sort -V | head -n1)" = "$MIN" ] || continue
+            SEL="$SEL $v"
+          done
+          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV)
+          echo "Selected MongoDB versions: $(echo $SEL | paste -sd' ' -)"
+
+          if [ -z "$(echo $SEL | tr -d '[:space:]')" ]; then
+            echo 'matrix={"version":[]}' >> "$GITHUB_OUTPUT"
+            echo 'build=false' >> "$GITHUB_OUTPUT"
+          else
+            MATRIX=$(printf '%s\n' $SEL | jq -R . | jq -cs '{version: .}')
+            echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+            echo 'build=true' >> "$GITHUB_OUTPUT"
+          fi
+
+  mongo:
+    name: MongoDB ${{ matrix.version }}
+    needs: discover
+    if: needs.discover.outputs.build == 'true'
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        version:
-          - "5"
-          - "6"
-          - "7"
-
+      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
@@ -35,18 +88,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ !env.ACT }}
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-        if: ${{ !env.ACT }}
-
       - uses: docker/build-push-action@v6
         with:
           context: mongo
           platforms: linux/amd64,linux/arm64
-          build-args: MONGO_VERSION=${{ matrix.version }}${{ matrix.modifier }}
+          build-args: MONGO_VERSION=${{ matrix.version }}
           push: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
-          tags: ghcr.io/${{ github.repository_owner }}/roll/mongo:${{ matrix.version }}${{ matrix.modifier }}
+          tags: ghcr.io/${{ github.repository_owner }}/roll/mongo:${{ matrix.version }}
         if: ${{ !env.ACT && github.ref == 'refs/heads/master'}}

--- a/.github/workflows/docker-image-mongo.yml
+++ b/.github/workflows/docker-image-mongo.yml
@@ -95,4 +95,4 @@ jobs:
           build-args: MONGO_VERSION=${{ matrix.version }}
           push: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
           tags: ghcr.io/${{ github.repository_owner }}/roll/mongo:${{ matrix.version }}
-        if: ${{ !env.ACT && github.ref == 'refs/heads/master'}}
+        if: ${{ !env.ACT }}

--- a/.github/workflows/docker-image-mysql.yml
+++ b/.github/workflows/docker-image-mysql.yml
@@ -1,32 +1,81 @@
 name: Docker Image MySQL
 on:
   workflow_dispatch:
+    inputs:
+      versions:
+        description: 'Modern MySQL versions to build (comma-separated). Empty = auto-discover.'
+        required: false
+        type: string
   schedule:
     - cron: "0 6 * * *" # 6 AM Daily
   push:
     paths:
+      - .trigger
       - mysql/**
       - .github/workflows/docker-image-mysql.yml
 
 jobs:
-  mysql:
-    name: MySQL
+  # Discover which modern versions to build: the pinned list is always built and
+  # any upstream version newer than the highest pinned one is added automatically.
+  # The major.minor tag is resolved to its latest patch at build time below.
+  # Edit PIN to curate, DENY to exclude, MIN for the floor. See README.
+  discover:
+    name: Discover MySQL versions
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.discover.outputs.matrix }}
+      build: ${{ steps.discover.outputs.build }}
+    steps:
+      - name: Discover versions
+        id: discover
+        run: |
+          set -uo pipefail
+          UPSTREAM="mysql"
+          MIN="8.0"                                          # floor — ignore anything older (legacy 5.x handled separately)
+          PIN="8.0.28 8.0 8.1 8.2 8.3 8.4 9.0 9.1 9.2"       # always built + fallback if discovery fails
+          DENY=""                                            # never build these
+          OVERRIDE="${{ inputs.versions }}"
 
+          MAXPIN=$(printf '%s\n' $PIN | sort -V | tail -1)
+          if [ -n "${OVERRIDE}" ]; then
+            CAND=$(echo "$OVERRIDE" | tr ', ' '\n' | grep -v '^$' || true)
+          else
+            DISCOVERED=$(docker run --rm gcr.io/go-containerregistry/crane ls "$UPSTREAM" 2>/dev/null \
+              | grep -E '^[0-9]+\.[0-9]+$' | sort -uV | paste -sd' ' - || true)
+            NEWER=""
+            for v in $DISCOVERED; do
+              [ "$v" = "$MAXPIN" ] && continue
+              [ "$(printf '%s\n%s\n' "$MAXPIN" "$v" | sort -V | tail -1)" = "$v" ] && NEWER="$NEWER $v"
+            done
+            CAND="$PIN $NEWER"
+          fi
+
+          SEL=""
+          for v in $CAND; do
+            case " $DENY " in *" $v "*) continue ;; esac
+            [ "$(printf '%s\n%s\n' "$MIN" "$v" | sort -V | head -n1)" = "$MIN" ] || continue
+            SEL="$SEL $v"
+          done
+          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV)
+          echo "Selected MySQL versions: $(echo $SEL | paste -sd' ' -)"
+
+          if [ -z "$(echo $SEL | tr -d '[:space:]')" ]; then
+            echo 'matrix={"version":[]}' >> "$GITHUB_OUTPUT"
+            echo 'build=false' >> "$GITHUB_OUTPUT"
+          else
+            MATRIX=$(printf '%s\n' $SEL | jq -R . | jq -cs '{version: .}')
+            echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+            echo 'build=true' >> "$GITHUB_OUTPUT"
+          fi
+
+  mysql:
+    name: MySQL ${{ matrix.version }}
+    needs: discover
+    if: needs.discover.outputs.build == 'true'
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        version:
-          - "8.0.28"
-          - "8.0"
-          - "8.1"
-          - "8.2"
-          - "8.3"
-          - "8.4"
-          - "9.0"
-          - "9.1"
-          - "9.2"
-
+      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
@@ -38,13 +87,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ !env.ACT }}
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
         if: ${{ !env.ACT }}
 
       - name: Set build-args
@@ -63,8 +105,10 @@ jobs:
           build-args: MYSQL_VERSION=${{ env.MYSQL_VERSION }}
           push: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
           tags: ghcr.io/${{ github.repository_owner }}/roll/mysql:${{ matrix.version }}
+
+  # Legacy 5.x is end-of-life upstream and amd64-only; kept as a fixed list.
   mysql-legacy:
-    name: MySQL Legacy
+    name: MySQL Legacy ${{ matrix.version }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -86,13 +130,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ !env.ACT }}
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
         if: ${{ !env.ACT }}
 
       - name: Set build-args

--- a/.github/workflows/docker-image-mysql.yml
+++ b/.github/workflows/docker-image-mysql.yml
@@ -56,7 +56,7 @@ jobs:
             [ "$(printf '%s\n%s\n' "$MIN" "$v" | sort -V | head -n1)" = "$MIN" ] || continue
             SEL="$SEL $v"
           done
-          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV)
+          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV || true)
           echo "Selected MySQL versions: $(echo $SEL | paste -sd' ' -)"
 
           if [ -z "$(echo $SEL | tr -d '[:space:]')" ]; then

--- a/.github/workflows/docker-image-nginx.yml
+++ b/.github/workflows/docker-image-nginx.yml
@@ -95,4 +95,4 @@ jobs:
           build-args: NGINX_VERSION=${{ matrix.version }}
           push: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
           tags: ghcr.io/${{ github.repository_owner }}/roll/nginx:${{ matrix.version }}
-        if: ${{ !env.ACT && github.ref == 'refs/heads/master'}}
+        if: ${{ !env.ACT }}

--- a/.github/workflows/docker-image-nginx.yml
+++ b/.github/workflows/docker-image-nginx.yml
@@ -55,7 +55,7 @@ jobs:
             [ "$(printf '%s\n%s\n' "$MIN" "$v" | sort -V | head -n1)" = "$MIN" ] || continue
             SEL="$SEL $v"
           done
-          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV)
+          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV || true)
           echo "Selected Nginx versions: $(echo $SEL | paste -sd' ' -)"
 
           if [ -z "$(echo $SEL | tr -d '[:space:]')" ]; then

--- a/.github/workflows/docker-image-nginx.yml
+++ b/.github/workflows/docker-image-nginx.yml
@@ -1,6 +1,11 @@
 name: Docker Image Nginx
 on:
   workflow_dispatch:
+    inputs:
+      versions:
+        description: 'Versions to build (comma-separated). Empty = auto-discover.'
+        required: false
+        type: string
   schedule:
     - cron: "0 6 * * *" # 6 AM Daily
   push:
@@ -10,19 +15,66 @@ on:
       - .github/workflows/*nginx*
 
 jobs:
-  nginx:
-    name: Nginx
+  # Discover which versions to build: the pinned list is always built and any
+  # upstream version newer than the highest pinned one is added automatically.
+  # Edit PIN to curate, DENY to exclude, MIN for the floor. See README.
+  discover:
+    name: Discover Nginx versions
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.discover.outputs.matrix }}
+      build: ${{ steps.discover.outputs.build }}
+    steps:
+      - name: Discover versions
+        id: discover
+        run: |
+          set -uo pipefail
+          UPSTREAM="nginx"
+          MIN="1.16"                              # floor — ignore anything older
+          PIN="1.16 1.25 1.26 1.27"               # always built + fallback if discovery fails
+          DENY=""                                 # never build these
+          OVERRIDE="${{ inputs.versions }}"
 
+          MAXPIN=$(printf '%s\n' $PIN | sort -V | tail -1)
+          if [ -n "${OVERRIDE}" ]; then
+            CAND=$(echo "$OVERRIDE" | tr ', ' '\n' | grep -v '^$' || true)
+          else
+            DISCOVERED=$(docker run --rm gcr.io/go-containerregistry/crane ls "$UPSTREAM" 2>/dev/null \
+              | grep -E '^[0-9]+\.[0-9]+$' | sort -uV | paste -sd' ' - || true)
+            NEWER=""
+            for v in $DISCOVERED; do
+              [ "$v" = "$MAXPIN" ] && continue
+              [ "$(printf '%s\n%s\n' "$MAXPIN" "$v" | sort -V | tail -1)" = "$v" ] && NEWER="$NEWER $v"
+            done
+            CAND="$PIN $NEWER"
+          fi
+
+          SEL=""
+          for v in $CAND; do
+            case " $DENY " in *" $v "*) continue ;; esac
+            [ "$(printf '%s\n%s\n' "$MIN" "$v" | sort -V | head -n1)" = "$MIN" ] || continue
+            SEL="$SEL $v"
+          done
+          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV)
+          echo "Selected Nginx versions: $(echo $SEL | paste -sd' ' -)"
+
+          if [ -z "$(echo $SEL | tr -d '[:space:]')" ]; then
+            echo 'matrix={"version":[]}' >> "$GITHUB_OUTPUT"
+            echo 'build=false' >> "$GITHUB_OUTPUT"
+          else
+            MATRIX=$(printf '%s\n' $SEL | jq -R . | jq -cs '{version: .}')
+            echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+            echo 'build=true' >> "$GITHUB_OUTPUT"
+          fi
+
+  nginx:
+    name: Nginx ${{ matrix.version }}
+    needs: discover
+    if: needs.discover.outputs.build == 'true'
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        version:
-          - "1.16"
-          - "1.25"
-          - "1.26"
-          - "1.27"
-
+      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
@@ -34,13 +86,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ !env.ACT }}
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
         if: ${{ !env.ACT }}
 
       - uses: docker/build-push-action@v6

--- a/.github/workflows/docker-image-opensearch.yml
+++ b/.github/workflows/docker-image-opensearch.yml
@@ -1,6 +1,11 @@
 name: Docker Image OpenSearch
 on:
   workflow_dispatch:
+    inputs:
+      versions:
+        description: 'Versions (major.minor, comma-separated). Empty = auto-discover.'
+        required: false
+        type: string
   schedule:
     - cron: "0 6 * * *" # 6 AM Daily
   push:
@@ -10,24 +15,69 @@ on:
       - .github/workflows/docker-image-opensearch.yml
 
 jobs:
-  opensearch:
-    name: OpenSearch
+  # Discover which versions to build: the pinned list is always built and any
+  # upstream major.minor newer than the highest pinned one is added automatically.
+  # The major.minor is resolved to its latest patch at build time below.
+  # Edit PIN to curate, DENY to exclude, MIN for the floor. See README.
+  discover:
+    name: Discover OpenSearch versions
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.discover.outputs.matrix }}
+      build: ${{ steps.discover.outputs.build }}
+    steps:
+      - name: Discover versions
+        id: discover
+        run: |
+          set -uo pipefail
+          UPSTREAM="docker.io/opensearchproject/opensearch"
+          MIN="2.9"                                              # floor — ignore anything older
+          PIN="2.9 2.10 2.11 2.12 2.13 2.19 3.1 3.2 3.3"         # always built + fallback if discovery fails
+          DENY=""                                                # never build these
+          OVERRIDE="${{ inputs.versions }}"
 
+          MAXPIN=$(printf '%s\n' $PIN | sort -V | tail -1)
+          if [ -n "${OVERRIDE}" ]; then
+            CAND=$(echo "$OVERRIDE" | tr ', ' '\n' | grep -v '^$' || true)
+          else
+            # Upstream publishes x.y.z tags; reduce to unique major.minor.
+            DISCOVERED=$(docker run --rm gcr.io/go-containerregistry/crane ls "$UPSTREAM" 2>/dev/null \
+              | sed 's/^v//' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | awk -F. '{print $1"."$2}' \
+              | sort -uV | paste -sd' ' - || true)
+            NEWER=""
+            for v in $DISCOVERED; do
+              [ "$v" = "$MAXPIN" ] && continue
+              [ "$(printf '%s\n%s\n' "$MAXPIN" "$v" | sort -V | tail -1)" = "$v" ] && NEWER="$NEWER $v"
+            done
+            CAND="$PIN $NEWER"
+          fi
+
+          SEL=""
+          for v in $CAND; do
+            case " $DENY " in *" $v "*) continue ;; esac
+            [ "$(printf '%s\n%s\n' "$MIN" "$v" | sort -V | head -n1)" = "$MIN" ] || continue
+            SEL="$SEL $v"
+          done
+          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV)
+          echo "Selected OpenSearch versions: $(echo $SEL | paste -sd' ' -)"
+
+          if [ -z "$(echo $SEL | tr -d '[:space:]')" ]; then
+            echo 'matrix={"version":[]}' >> "$GITHUB_OUTPUT"
+            echo 'build=false' >> "$GITHUB_OUTPUT"
+          else
+            MATRIX=$(printf '%s\n' $SEL | jq -R . | jq -cs '{version: .}')
+            echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+            echo 'build=true' >> "$GITHUB_OUTPUT"
+          fi
+
+  opensearch:
+    name: OpenSearch ${{ matrix.version }}
+    needs: discover
+    if: needs.discover.outputs.build == 'true'
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        version:
-          - "2.9"
-          - "2.10"
-          - "2.11"
-          - "2.12"
-          - "2.13"
-          - "2.19"
-          - "3.1"
-          - "3.2"
-          - "3.3"
-
+      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
@@ -39,13 +89,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ !env.ACT }}
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
         if: ${{ !env.ACT }}
 
       - name: Set build-args

--- a/.github/workflows/docker-image-opensearch.yml
+++ b/.github/workflows/docker-image-opensearch.yml
@@ -58,7 +58,7 @@ jobs:
             [ "$(printf '%s\n%s\n' "$MIN" "$v" | sort -V | head -n1)" = "$MIN" ] || continue
             SEL="$SEL $v"
           done
-          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV)
+          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV || true)
           echo "Selected OpenSearch versions: $(echo $SEL | paste -sd' ' -)"
 
           if [ -z "$(echo $SEL | tr -d '[:space:]')" ]; then

--- a/.github/workflows/docker-image-php-fpm.yml
+++ b/.github/workflows/docker-image-php-fpm.yml
@@ -83,14 +83,14 @@ jobs:
             # major.minor -fpm- (bullseye|bookworm) tags only; patch tags ignored.
             PHP_VERSIONS=$(crane ls "${PHP_SRC}" 2>/dev/null \
               | grep -E '^[0-9]+\.[0-9]+-fpm-(bullseye|bookworm)$' \
-              | sed 's/-fpm-.*//' | sort -uV | paste -sd, -)
+              | sed 's/-fpm-.*//' | sort -uV | paste -sd, - || true)
           fi
           if [ -n "${NODE_IN}" ]; then
             NODE_VERSIONS="${NODE_IN}"
           else
             NODE_VERSIONS=$(crane ls "${NODE_SRC}" 2>/dev/null \
               | grep -E '^[0-9]+-(bullseye|bookworm)$' \
-              | sed 's/-.*//' | sort -un | paste -sd, -)
+              | sed 's/-.*//' | sort -un | paste -sd, - || true)
           fi
 
           echo "php_versions=${PHP_VERSIONS}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker-image-php-fpm.yml
+++ b/.github/workflows/docker-image-php-fpm.yml
@@ -61,38 +61,58 @@ jobs:
           set -uo pipefail
           OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           MIRROR="ghcr.io/${OWNER}/base-images"
+          # Keep in sync with PHP_MIN_VERSION in php-matrix/constants.php — the
+          # mirror must carry every PHP version php-fpm might build (down to this
+          # floor) or it can't safely serve as the build base.
+          PHP_FLOOR="7.3"
 
-          # Prefer the GHCR mirror of the base images (insulated from Docker Hub
-          # rate limits); fall back to Docker Hub when the mirror is absent.
-          if crane ls "${MIRROR}/php" >/dev/null 2>&1; then
-            REGISTRY_BASE="${MIRROR}"; PHP_SRC="${MIRROR}/php"; NODE_SRC="${MIRROR}/node"
-            echo "Using mirrored base images: ${MIRROR}"
-          else
-            REGISTRY_BASE=""; PHP_SRC="php"; NODE_SRC="node"
-            echo "Mirror not found; using Docker Hub base images"
-          fi
-          echo "registry_base=${REGISTRY_BASE}" >> "$GITHUB_OUTPUT"
+          # Keep only versions >= PHP_FLOOR (uses `if`, so a non-match can't trip
+          # the runner's `set -e`).
+          above_floor() {
+            while read -r v; do
+              [ -n "$v" ] || continue
+              if [ "$(printf '%s\n%s\n' "$PHP_FLOOR" "$v" | sort -V | head -n1)" = "$PHP_FLOOR" ]; then
+                echo "$v"
+              fi
+            done
+          }
+
+          # Discover from Docker Hub. This is a single cheap tag listing; the
+          # rate-limit-sensitive part is the per-arch BUILD pulls, which use the
+          # mirror when it is complete (decided below).
+          DH_PHP_MM=$(crane ls php 2>/dev/null \
+            | grep -E '^[0-9]+\.[0-9]+-fpm-(bullseye|bookworm)$' \
+            | sed 's/-fpm-.*//' | sort -uV | above_floor || true)
+          DH_NODE_MM=$(crane ls node 2>/dev/null \
+            | grep -E '^[0-9]+-(bullseye|bookworm)$' | sed 's/-.*//' | sort -un || true)
 
           # Manual override via workflow_dispatch wins over discovery.
           PHP_IN="${{ inputs.php_versions }}"
           NODE_IN="${{ inputs.node_versions }}"
+          if [ -n "${PHP_IN}" ]; then PHP_VERSIONS="${PHP_IN}"; else PHP_VERSIONS=$(echo "$DH_PHP_MM" | paste -sd, - || true); fi
+          if [ -n "${NODE_IN}" ]; then NODE_VERSIONS="${NODE_IN}"; else NODE_VERSIONS=$(echo "$DH_NODE_MM" | paste -sd, - || true); fi
 
-          if [ -n "${PHP_IN}" ]; then
-            PHP_VERSIONS="${PHP_IN}"
-          else
-            # major.minor -fpm- (bullseye|bookworm) tags only; patch tags ignored.
-            PHP_VERSIONS=$(crane ls "${PHP_SRC}" 2>/dev/null \
+          # Use the mirror as the php build base ONLY when it already contains
+          # every PHP major.minor Docker Hub offers above the floor. "Repo exists"
+          # is not enough: a partially-populated mirror (e.g. a previous run
+          # failed mid-way) would make some builds pull a missing base and fail.
+          REGISTRY_BASE=""
+          if crane ls "${MIRROR}/php" >/dev/null 2>&1; then
+            MIRROR_PHP_MM=$(crane ls "${MIRROR}/php" 2>/dev/null \
               | grep -E '^[0-9]+\.[0-9]+-fpm-(bullseye|bookworm)$' \
-              | sed 's/-fpm-.*//' | sort -uV | paste -sd, - || true)
-          fi
-          if [ -n "${NODE_IN}" ]; then
-            NODE_VERSIONS="${NODE_IN}"
+              | sed 's/-fpm-.*//' | sort -uV || true)
+            MISSING=$(comm -23 <(printf '%s\n' $DH_PHP_MM | sort -u) <(printf '%s\n' $MIRROR_PHP_MM | sort -u))
+            if [ -z "$(echo $MISSING | tr -d '[:space:]')" ] && [ -n "$(echo $DH_PHP_MM | tr -d '[:space:]')" ]; then
+              REGISTRY_BASE="${MIRROR}"
+              echo "Mirror is complete; using ${MIRROR} as the php build base."
+            else
+              echo "Mirror incomplete (missing: $(echo $MISSING | paste -sd' ' -)); using Docker Hub as the php build base."
+            fi
           else
-            NODE_VERSIONS=$(crane ls "${NODE_SRC}" 2>/dev/null \
-              | grep -E '^[0-9]+-(bullseye|bookworm)$' \
-              | sed 's/-.*//' | sort -un | paste -sd, - || true)
+            echo "Mirror not present; using Docker Hub as the php build base."
           fi
 
+          echo "registry_base=${REGISTRY_BASE}" >> "$GITHUB_OUTPUT"
           echo "php_versions=${PHP_VERSIONS}" >> "$GITHUB_OUTPUT"
           echo "node_versions=${NODE_VERSIONS}" >> "$GITHUB_OUTPUT"
           echo "Discovered PHP: ${PHP_VERSIONS:-<none — generators use pinned fallback>}"

--- a/.github/workflows/docker-image-php-fpm.yml
+++ b/.github/workflows/docker-image-php-fpm.yml
@@ -1,6 +1,15 @@
 name: Docker Image PHP-FPM
 on:
   workflow_dispatch:
+    inputs:
+      php_versions:
+        description: 'PHP versions to build (comma-separated). Leave empty to auto-discover from the registry.'
+        required: false
+        type: string
+      node_versions:
+        description: 'Node versions to build (comma-separated). Leave empty to auto-discover from the registry.'
+        required: false
+        type: string
   schedule:
     - cron: "0 6 * * *"   # 6 AM daily
   pull_request:
@@ -22,8 +31,76 @@ env:
   REGISTRY_WORDPRESS: ghcr.io/epartment/roll/php-fpm-wordpress
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Discover which PHP / Node versions to build by listing the upstream tags
+  # with crane, then hand them to the matrix generators. Floor, deny-list and
+  # pinned fallbacks live in php-matrix/constants.php — this job only supplies
+  # the raw discovered lists (the generators apply the policy). If discovery
+  # returns nothing (registry hiccup) the generators fall back to the pinned
+  # lists, so the build never stalls for lack of a version list.
+  # ---------------------------------------------------------------------------
+  discover:
+    name: Discover PHP & Node versions
+    runs-on: ubuntu-latest
+    outputs:
+      php_versions: ${{ steps.discover.outputs.php_versions }}
+      node_versions: ${{ steps.discover.outputs.node_versions }}
+      registry_base: ${{ steps.discover.outputs.registry_base }}
+    steps:
+      - uses: imjasonh/setup-crane@v0.4
+      - name: Login to GHCR
+        if: ${{ !env.ACT }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Discover versions
+        id: discover
+        run: |
+          set -uo pipefail
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          MIRROR="ghcr.io/${OWNER}/base-images"
+
+          # Prefer the GHCR mirror of the base images (insulated from Docker Hub
+          # rate limits); fall back to Docker Hub when the mirror is absent.
+          if crane ls "${MIRROR}/php" >/dev/null 2>&1; then
+            REGISTRY_BASE="${MIRROR}"; PHP_SRC="${MIRROR}/php"; NODE_SRC="${MIRROR}/node"
+            echo "Using mirrored base images: ${MIRROR}"
+          else
+            REGISTRY_BASE=""; PHP_SRC="php"; NODE_SRC="node"
+            echo "Mirror not found; using Docker Hub base images"
+          fi
+          echo "registry_base=${REGISTRY_BASE}" >> "$GITHUB_OUTPUT"
+
+          # Manual override via workflow_dispatch wins over discovery.
+          PHP_IN="${{ inputs.php_versions }}"
+          NODE_IN="${{ inputs.node_versions }}"
+
+          if [ -n "${PHP_IN}" ]; then
+            PHP_VERSIONS="${PHP_IN}"
+          else
+            # major.minor -fpm- (bullseye|bookworm) tags only; patch tags ignored.
+            PHP_VERSIONS=$(crane ls "${PHP_SRC}" 2>/dev/null \
+              | grep -E '^[0-9]+\.[0-9]+-fpm-(bullseye|bookworm)$' \
+              | sed 's/-fpm-.*//' | sort -uV | paste -sd, -)
+          fi
+          if [ -n "${NODE_IN}" ]; then
+            NODE_VERSIONS="${NODE_IN}"
+          else
+            NODE_VERSIONS=$(crane ls "${NODE_SRC}" 2>/dev/null \
+              | grep -E '^[0-9]+-(bullseye|bookworm)$' \
+              | sed 's/-.*//' | sort -un | paste -sd, -)
+          fi
+
+          echo "php_versions=${PHP_VERSIONS}" >> "$GITHUB_OUTPUT"
+          echo "node_versions=${NODE_VERSIONS}" >> "$GITHUB_OUTPUT"
+          echo "Discovered PHP: ${PHP_VERSIONS:-<none — generators use pinned fallback>}"
+          echo "Discovered Node: ${NODE_VERSIONS:-<none — generators use pinned fallback>}"
+
   php-matrix:
     name: Generate Base PHP Matrix
+    needs: discover
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
@@ -33,11 +110,15 @@ jobs:
         with:
           php-version: 8.4
       - id: matrix
+        env:
+          DISCOVERED_PHP_VERSIONS: ${{ needs.discover.outputs.php_versions }}
+          DISCOVERED_NODE_VERSIONS: ${{ needs.discover.outputs.node_versions }}
         run: |
           php .github/workflows/php-matrix/php-generator.php >> $GITHUB_OUTPUT
       - run: echo "Matrix:\n";echo '${{ steps.matrix.outputs.matrix }}'
   node-matrix:
     name: Generate Base PHP-Node Matrix
+    needs: discover
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
@@ -47,11 +128,15 @@ jobs:
         with:
           php-version: 8.4
       - id: matrix
+        env:
+          DISCOVERED_PHP_VERSIONS: ${{ needs.discover.outputs.php_versions }}
+          DISCOVERED_NODE_VERSIONS: ${{ needs.discover.outputs.node_versions }}
         run: |
           php .github/workflows/php-matrix/node-generator.php >> $GITHUB_OUTPUT
       - run: echo "Matrix:\n";echo '${{ steps.matrix.outputs.matrix }}'
   full-matrix:
     name: Generate Full Matrix
+    needs: discover
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
@@ -61,12 +146,15 @@ jobs:
         with:
           php-version: 8.4
       - id: matrix
+        env:
+          DISCOVERED_PHP_VERSIONS: ${{ needs.discover.outputs.php_versions }}
+          DISCOVERED_NODE_VERSIONS: ${{ needs.discover.outputs.node_versions }}
         run: |
           php .github/workflows/php-matrix/full-generator.php >> $GITHUB_OUTPUT
       - run: echo "Matrix:\n";echo '${{ steps.matrix.outputs.matrix }}'
 
   php-fpm-build:
-    needs: php-matrix
+    needs: [ discover, php-matrix ]
     name: PHP-FPM ${{ matrix.php_version }} (${{ matrix.arch.cache_arch }})
     runs-on: ${{ matrix.arch.runs_on }}
     permissions:
@@ -91,13 +179,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to Docker Hub
-        if: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Build and push by digest (${{ matrix.arch.cache_arch }})
         id: build
         uses: docker/build-push-action@v6
@@ -108,7 +189,7 @@ jobs:
           build-args: |
             PHP_VERSION=${{ matrix.php_version }}
             OS_RELEASE=${{ matrix.php_os_release }}
-            ENV_SOURCE_IMAGE=php
+            ENV_SOURCE_IMAGE=${{ needs.discover.outputs.registry_base != '' && format('{0}/php', needs.discover.outputs.registry_base) || 'php' }}
           tags: ${{ env.REGISTRY_IMAGE }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/roll/php-fpm:${{ matrix.php_version }}-${{ matrix.arch.cache_suffix }}-buildcache
@@ -154,13 +235,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ !env.ACT }}
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
         if: ${{ !env.ACT }}
 
       - uses: docker/build-push-action@v6
@@ -223,13 +297,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to Docker Hub
-        if: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Build and push by digest (${{ matrix.arch.cache_arch }})
         id: build
         uses: docker/build-push-action@v6
@@ -290,13 +357,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to Docker Hub
-        if: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Build and push by digest (${{ matrix.arch.cache_arch }})
         id: build
         uses: docker/build-push-action@v6
@@ -356,13 +416,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to Docker Hub
-        if: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Build and push by digest (${{ matrix.arch.cache_arch }})
         id: build
         uses: docker/build-push-action@v6
@@ -421,13 +474,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to Docker Hub
-        if: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push by digest (${{ matrix.arch.cache_arch }})
         id: build
@@ -489,13 +535,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to Docker Hub
-        if: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Build and push by digest (${{ matrix.arch.cache_arch }})
         id: build
         uses: docker/build-push-action@v6
@@ -530,7 +569,10 @@ jobs:
 
   merge:
     needs: [ php-fpm-build, php-node ]
-    if: ${{ github.ref == 'refs/heads/master' }}
+    # Run even when some build-matrix entries failed, so the combinations that
+    # *did* build are still published. A single flaky build no longer blocks
+    # every tag (only `cancelled()` — e.g. a manual cancel — stops the merge).
+    if: ${{ !cancelled() && github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -555,36 +597,69 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to Docker Hub
-        if: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Create and push manifests per PHP version
         working-directory: ${{ runner.temp }}/digests
         run: |
-          set -euo pipefail
+          set -uo pipefail
           REGISTRY_IMAGE="${{ env.REGISTRY_IMAGE }}"
+          # Every image here is built for both architectures, so a complete
+          # multi-arch tag needs exactly this many per-arch digests. A version
+          # with fewer (a flaky single-arch failure) is skipped rather than
+          # published as a broken single-arch manifest — it keeps its previous
+          # image until the next run. Other, complete versions still publish.
+          EXPECTED_ARCHES=2
+
+          shopt -s nullglob
+          if [ -z "$(ls -A 2>/dev/null)" ]; then
+            echo "::warning::No digest artifacts found for ${REGISTRY_IMAGE} — nothing to merge."
+            exit 0
+          fi
+
+          # Digest files are named "<sha256-hex>-<version>" (version may itself
+          # contain dashes, e.g. "8.3-node18"); the sha is dash-free so field 2+
+          # is the version.
           version_names=$(ls | cut -d- -f 2- | sort -u)
+          published=0
+          skipped=0
           # no latest tag creation; only per-version manifests
           for version in $version_names; do
             references=""
+            count=0
             for file in *-"${version}"; do
+              [ -e "$file" ] || continue
               digest_sha256=${file%-${version}}
               references="$references $REGISTRY_IMAGE@sha256:${digest_sha256}"
+              count=$((count + 1))
             done
-            tag_arguments="-t $REGISTRY_IMAGE:${version}"
 
-            echo "Creating manifest for ${version} with references:${references} and tag arguments:${tag_arguments}"
+            if [ "$count" -lt "$EXPECTED_ARCHES" ]; then
+              echo "::warning::Skipping ${REGISTRY_IMAGE}:${version} — only ${count}/${EXPECTED_ARCHES} arch digest(s) present; keeping previous image."
+              skipped=$((skipped + 1))
+              continue
+            fi
+
+            echo "Creating manifest for ${version} (${count} arches):${references}"
             # shellcheck disable=SC2086
-            docker buildx imagetools create ${tag_arguments} ${references}
+            if docker buildx imagetools create -t "$REGISTRY_IMAGE:${version}" ${references}; then
+              published=$((published + 1))
+            else
+              echo "::warning::Failed to publish ${REGISTRY_IMAGE}:${version}; continuing with remaining versions."
+              skipped=$((skipped + 1))
+            fi
           done
+
+          echo "Published ${published} tag(s), skipped ${skipped}, for ${REGISTRY_IMAGE}."
+          if [ "$published" -eq 0 ]; then
+            echo "::error::No ${REGISTRY_IMAGE} tags could be published."
+            exit 1
+          fi
 
   merge-xdebug:
     needs: [ xdebug ]
-    if: ${{ github.ref == 'refs/heads/master' }}
+    # Run even when some build-matrix entries failed, so the combinations that
+    # *did* build are still published. A single flaky build no longer blocks
+    # every tag (only `cancelled()` — e.g. a manual cancel — stops the merge).
+    if: ${{ !cancelled() && github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -609,36 +684,69 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to Docker Hub
-        if: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Create and push manifests per PHP version
         working-directory: ${{ runner.temp }}/xdebug-digests
         run: |
-          set -euo pipefail
+          set -uo pipefail
           REGISTRY_IMAGE="${{ env.REGISTRY_XDEBUG }}"
+          # Every image here is built for both architectures, so a complete
+          # multi-arch tag needs exactly this many per-arch digests. A version
+          # with fewer (a flaky single-arch failure) is skipped rather than
+          # published as a broken single-arch manifest — it keeps its previous
+          # image until the next run. Other, complete versions still publish.
+          EXPECTED_ARCHES=2
+
+          shopt -s nullglob
+          if [ -z "$(ls -A 2>/dev/null)" ]; then
+            echo "::warning::No digest artifacts found for ${REGISTRY_IMAGE} — nothing to merge."
+            exit 0
+          fi
+
+          # Digest files are named "<sha256-hex>-<version>" (version may itself
+          # contain dashes, e.g. "8.3-node18"); the sha is dash-free so field 2+
+          # is the version.
           version_names=$(ls | cut -d- -f 2- | sort -u)
+          published=0
+          skipped=0
           # no latest tag creation; only per-version manifests
           for version in $version_names; do
             references=""
+            count=0
             for file in *-"${version}"; do
+              [ -e "$file" ] || continue
               digest_sha256=${file%-${version}}
               references="$references $REGISTRY_IMAGE@sha256:${digest_sha256}"
+              count=$((count + 1))
             done
-            tag_arguments="-t $REGISTRY_IMAGE:${version}"
 
-            echo "Creating manifest for ${version} with references:${references} and tag arguments:${tag_arguments}"
+            if [ "$count" -lt "$EXPECTED_ARCHES" ]; then
+              echo "::warning::Skipping ${REGISTRY_IMAGE}:${version} — only ${count}/${EXPECTED_ARCHES} arch digest(s) present; keeping previous image."
+              skipped=$((skipped + 1))
+              continue
+            fi
+
+            echo "Creating manifest for ${version} (${count} arches):${references}"
             # shellcheck disable=SC2086
-            docker buildx imagetools create ${tag_arguments} ${references}
+            if docker buildx imagetools create -t "$REGISTRY_IMAGE:${version}" ${references}; then
+              published=$((published + 1))
+            else
+              echo "::warning::Failed to publish ${REGISTRY_IMAGE}:${version}; continuing with remaining versions."
+              skipped=$((skipped + 1))
+            fi
           done
+
+          echo "Published ${published} tag(s), skipped ${skipped}, for ${REGISTRY_IMAGE}."
+          if [ "$published" -eq 0 ]; then
+            echo "::error::No ${REGISTRY_IMAGE} tags could be published."
+            exit 1
+          fi
 
   merge-magento1:
     needs: [ magento1 ]
-    if: ${{ github.ref == 'refs/heads/master' }}
+    # Run even when some build-matrix entries failed, so the combinations that
+    # *did* build are still published. A single flaky build no longer blocks
+    # every tag (only `cancelled()` — e.g. a manual cancel — stops the merge).
+    if: ${{ !cancelled() && github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -663,36 +771,69 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to Docker Hub
-        if: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Create and push manifests per PHP version
         working-directory: ${{ runner.temp }}/magento1-digests
         run: |
-          set -euo pipefail
+          set -uo pipefail
           REGISTRY_IMAGE="${{ env.REGISTRY_MAGENTO1 }}"
+          # Every image here is built for both architectures, so a complete
+          # multi-arch tag needs exactly this many per-arch digests. A version
+          # with fewer (a flaky single-arch failure) is skipped rather than
+          # published as a broken single-arch manifest — it keeps its previous
+          # image until the next run. Other, complete versions still publish.
+          EXPECTED_ARCHES=2
+
+          shopt -s nullglob
+          if [ -z "$(ls -A 2>/dev/null)" ]; then
+            echo "::warning::No digest artifacts found for ${REGISTRY_IMAGE} — nothing to merge."
+            exit 0
+          fi
+
+          # Digest files are named "<sha256-hex>-<version>" (version may itself
+          # contain dashes, e.g. "8.3-node18"); the sha is dash-free so field 2+
+          # is the version.
           version_names=$(ls | cut -d- -f 2- | sort -u)
+          published=0
+          skipped=0
           # no latest tag creation; only per-version manifests
           for version in $version_names; do
             references=""
+            count=0
             for file in *-"${version}"; do
+              [ -e "$file" ] || continue
               digest_sha256=${file%-${version}}
               references="$references $REGISTRY_IMAGE@sha256:${digest_sha256}"
+              count=$((count + 1))
             done
-            tag_arguments="-t $REGISTRY_IMAGE:${version}"
 
-            echo "Creating manifest for ${version} with references:${references} and tag arguments:${tag_arguments}"
+            if [ "$count" -lt "$EXPECTED_ARCHES" ]; then
+              echo "::warning::Skipping ${REGISTRY_IMAGE}:${version} — only ${count}/${EXPECTED_ARCHES} arch digest(s) present; keeping previous image."
+              skipped=$((skipped + 1))
+              continue
+            fi
+
+            echo "Creating manifest for ${version} (${count} arches):${references}"
             # shellcheck disable=SC2086
-            docker buildx imagetools create ${tag_arguments} ${references}
+            if docker buildx imagetools create -t "$REGISTRY_IMAGE:${version}" ${references}; then
+              published=$((published + 1))
+            else
+              echo "::warning::Failed to publish ${REGISTRY_IMAGE}:${version}; continuing with remaining versions."
+              skipped=$((skipped + 1))
+            fi
           done
+
+          echo "Published ${published} tag(s), skipped ${skipped}, for ${REGISTRY_IMAGE}."
+          if [ "$published" -eq 0 ]; then
+            echo "::error::No ${REGISTRY_IMAGE} tags could be published."
+            exit 1
+          fi
 
   merge-magento2:
     needs: [ magento2 ]
-    if: ${{ github.ref == 'refs/heads/master' }}
+    # Run even when some build-matrix entries failed, so the combinations that
+    # *did* build are still published. A single flaky build no longer blocks
+    # every tag (only `cancelled()` — e.g. a manual cancel — stops the merge).
+    if: ${{ !cancelled() && github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -717,36 +858,69 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to Docker Hub
-        if: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Create and push manifests per PHP version
         working-directory: ${{ runner.temp }}/magento2-digests
         run: |
-          set -euo pipefail
+          set -uo pipefail
           REGISTRY_IMAGE="${{ env.REGISTRY_MAGENTO2 }}"
+          # Every image here is built for both architectures, so a complete
+          # multi-arch tag needs exactly this many per-arch digests. A version
+          # with fewer (a flaky single-arch failure) is skipped rather than
+          # published as a broken single-arch manifest — it keeps its previous
+          # image until the next run. Other, complete versions still publish.
+          EXPECTED_ARCHES=2
+
+          shopt -s nullglob
+          if [ -z "$(ls -A 2>/dev/null)" ]; then
+            echo "::warning::No digest artifacts found for ${REGISTRY_IMAGE} — nothing to merge."
+            exit 0
+          fi
+
+          # Digest files are named "<sha256-hex>-<version>" (version may itself
+          # contain dashes, e.g. "8.3-node18"); the sha is dash-free so field 2+
+          # is the version.
           version_names=$(ls | cut -d- -f 2- | sort -u)
+          published=0
+          skipped=0
           # no latest tag creation; only per-version manifests
           for version in $version_names; do
             references=""
+            count=0
             for file in *-"${version}"; do
+              [ -e "$file" ] || continue
               digest_sha256=${file%-${version}}
               references="$references $REGISTRY_IMAGE@sha256:${digest_sha256}"
+              count=$((count + 1))
             done
-            tag_arguments="-t $REGISTRY_IMAGE:${version}"
 
-            echo "Creating manifest for ${version} with references:${references} and tag arguments:${tag_arguments}"
+            if [ "$count" -lt "$EXPECTED_ARCHES" ]; then
+              echo "::warning::Skipping ${REGISTRY_IMAGE}:${version} — only ${count}/${EXPECTED_ARCHES} arch digest(s) present; keeping previous image."
+              skipped=$((skipped + 1))
+              continue
+            fi
+
+            echo "Creating manifest for ${version} (${count} arches):${references}"
             # shellcheck disable=SC2086
-            docker buildx imagetools create ${tag_arguments} ${references}
+            if docker buildx imagetools create -t "$REGISTRY_IMAGE:${version}" ${references}; then
+              published=$((published + 1))
+            else
+              echo "::warning::Failed to publish ${REGISTRY_IMAGE}:${version}; continuing with remaining versions."
+              skipped=$((skipped + 1))
+            fi
           done
+
+          echo "Published ${published} tag(s), skipped ${skipped}, for ${REGISTRY_IMAGE}."
+          if [ "$published" -eq 0 ]; then
+            echo "::error::No ${REGISTRY_IMAGE} tags could be published."
+            exit 1
+          fi
 
   merge-magento2-xdebug:
     needs: [ magento2-xdebug ]
-    if: ${{ github.ref == 'refs/heads/master' }}
+    # Run even when some build-matrix entries failed, so the combinations that
+    # *did* build are still published. A single flaky build no longer blocks
+    # every tag (only `cancelled()` — e.g. a manual cancel — stops the merge).
+    if: ${{ !cancelled() && github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -771,36 +945,69 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to Docker Hub
-        if: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Create and push manifests per PHP version
         working-directory: ${{ runner.temp }}/magento2-debug-digests
         run: |
-          set -euo pipefail
+          set -uo pipefail
           REGISTRY_IMAGE="${{ env.REGISTRY_MAGENTO2_DEBUG }}"
+          # Every image here is built for both architectures, so a complete
+          # multi-arch tag needs exactly this many per-arch digests. A version
+          # with fewer (a flaky single-arch failure) is skipped rather than
+          # published as a broken single-arch manifest — it keeps its previous
+          # image until the next run. Other, complete versions still publish.
+          EXPECTED_ARCHES=2
+
+          shopt -s nullglob
+          if [ -z "$(ls -A 2>/dev/null)" ]; then
+            echo "::warning::No digest artifacts found for ${REGISTRY_IMAGE} — nothing to merge."
+            exit 0
+          fi
+
+          # Digest files are named "<sha256-hex>-<version>" (version may itself
+          # contain dashes, e.g. "8.3-node18"); the sha is dash-free so field 2+
+          # is the version.
           version_names=$(ls | cut -d- -f 2- | sort -u)
+          published=0
+          skipped=0
           # no latest tag creation; only per-version manifests
           for version in $version_names; do
             references=""
+            count=0
             for file in *-"${version}"; do
+              [ -e "$file" ] || continue
               digest_sha256=${file%-${version}}
               references="$references $REGISTRY_IMAGE@sha256:${digest_sha256}"
+              count=$((count + 1))
             done
-            tag_arguments="-t $REGISTRY_IMAGE:${version}"
 
-            echo "Creating manifest for ${version} with references:${references} and tag arguments:${tag_arguments}"
+            if [ "$count" -lt "$EXPECTED_ARCHES" ]; then
+              echo "::warning::Skipping ${REGISTRY_IMAGE}:${version} — only ${count}/${EXPECTED_ARCHES} arch digest(s) present; keeping previous image."
+              skipped=$((skipped + 1))
+              continue
+            fi
+
+            echo "Creating manifest for ${version} (${count} arches):${references}"
             # shellcheck disable=SC2086
-            docker buildx imagetools create ${tag_arguments} ${references}
+            if docker buildx imagetools create -t "$REGISTRY_IMAGE:${version}" ${references}; then
+              published=$((published + 1))
+            else
+              echo "::warning::Failed to publish ${REGISTRY_IMAGE}:${version}; continuing with remaining versions."
+              skipped=$((skipped + 1))
+            fi
           done
+
+          echo "Published ${published} tag(s), skipped ${skipped}, for ${REGISTRY_IMAGE}."
+          if [ "$published" -eq 0 ]; then
+            echo "::error::No ${REGISTRY_IMAGE} tags could be published."
+            exit 1
+          fi
 
   merge-wordpress:
     needs: [ wordpress ]
-    if: ${{ github.ref == 'refs/heads/master' }}
+    # Run even when some build-matrix entries failed, so the combinations that
+    # *did* build are still published. A single flaky build no longer blocks
+    # every tag (only `cancelled()` — e.g. a manual cancel — stops the merge).
+    if: ${{ !cancelled() && github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -825,29 +1032,59 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to Docker Hub
-        if: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Create and push manifests per PHP version
         working-directory: ${{ runner.temp }}/wordpress-digests
         run: |
-          set -euo pipefail
+          set -uo pipefail
           REGISTRY_IMAGE="${{ env.REGISTRY_WORDPRESS }}"
+          # Every image here is built for both architectures, so a complete
+          # multi-arch tag needs exactly this many per-arch digests. A version
+          # with fewer (a flaky single-arch failure) is skipped rather than
+          # published as a broken single-arch manifest — it keeps its previous
+          # image until the next run. Other, complete versions still publish.
+          EXPECTED_ARCHES=2
+
+          shopt -s nullglob
+          if [ -z "$(ls -A 2>/dev/null)" ]; then
+            echo "::warning::No digest artifacts found for ${REGISTRY_IMAGE} — nothing to merge."
+            exit 0
+          fi
+
+          # Digest files are named "<sha256-hex>-<version>" (version may itself
+          # contain dashes, e.g. "8.3-node18"); the sha is dash-free so field 2+
+          # is the version.
           version_names=$(ls | cut -d- -f 2- | sort -u)
+          published=0
+          skipped=0
           # no latest tag creation; only per-version manifests
           for version in $version_names; do
             references=""
+            count=0
             for file in *-"${version}"; do
+              [ -e "$file" ] || continue
               digest_sha256=${file%-${version}}
               references="$references $REGISTRY_IMAGE@sha256:${digest_sha256}"
+              count=$((count + 1))
             done
-            tag_arguments="-t $REGISTRY_IMAGE:${version}"
 
-            echo "Creating manifest for ${version} with references:${references} and tag arguments:${tag_arguments}"
+            if [ "$count" -lt "$EXPECTED_ARCHES" ]; then
+              echo "::warning::Skipping ${REGISTRY_IMAGE}:${version} — only ${count}/${EXPECTED_ARCHES} arch digest(s) present; keeping previous image."
+              skipped=$((skipped + 1))
+              continue
+            fi
+
+            echo "Creating manifest for ${version} (${count} arches):${references}"
             # shellcheck disable=SC2086
-            docker buildx imagetools create ${tag_arguments} ${references}
+            if docker buildx imagetools create -t "$REGISTRY_IMAGE:${version}" ${references}; then
+              published=$((published + 1))
+            else
+              echo "::warning::Failed to publish ${REGISTRY_IMAGE}:${version}; continuing with remaining versions."
+              skipped=$((skipped + 1))
+            fi
           done
+
+          echo "Published ${published} tag(s), skipped ${skipped}, for ${REGISTRY_IMAGE}."
+          if [ "$published" -eq 0 ]; then
+            echo "::error::No ${REGISTRY_IMAGE} tags could be published."
+            exit 1
+          fi

--- a/.github/workflows/docker-image-rabbitmq.yml
+++ b/.github/workflows/docker-image-rabbitmq.yml
@@ -55,7 +55,7 @@ jobs:
             [ "$(printf '%s\n%s\n' "$MIN" "$v" | sort -V | head -n1)" = "$MIN" ] || continue
             SEL="$SEL $v"
           done
-          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV)
+          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV || true)
           echo "Selected RabbitMQ versions: $(echo $SEL | paste -sd' ' -)"
 
           if [ -z "$(echo $SEL | tr -d '[:space:]')" ]; then

--- a/.github/workflows/docker-image-rabbitmq.yml
+++ b/.github/workflows/docker-image-rabbitmq.yml
@@ -95,4 +95,4 @@ jobs:
           build-args: RABBITMQ_VERSION=${{ matrix.version }}
           push: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
           tags: ghcr.io/${{ github.repository_owner }}/roll/rabbitmq:${{ matrix.version }}
-        if: ${{ !env.ACT && github.ref == 'refs/heads/master'}}
+        if: ${{ !env.ACT }}

--- a/.github/workflows/docker-image-rabbitmq.yml
+++ b/.github/workflows/docker-image-rabbitmq.yml
@@ -1,6 +1,11 @@
 name: Docker Image RabbitMQ
 on:
   workflow_dispatch:
+    inputs:
+      versions:
+        description: 'Versions to build (comma-separated). Empty = auto-discover.'
+        required: false
+        type: string
   schedule:
     - cron: "0 6 * * *" # 6 AM Daily
   push:
@@ -10,26 +15,66 @@ on:
       - .github/workflows/*rabbitmq*
 
 jobs:
-  rabbitmq:
-    name: RabbitMQ
+  # Discover which versions to build: the pinned list is always built and any
+  # upstream version newer than the highest pinned one is added automatically.
+  # Edit PIN to curate, DENY to exclude, MIN for the floor. See README.
+  discover:
+    name: Discover RabbitMQ versions
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.discover.outputs.matrix }}
+      build: ${{ steps.discover.outputs.build }}
+    steps:
+      - name: Discover versions
+        id: discover
+        run: |
+          set -uo pipefail
+          UPSTREAM="rabbitmq"
+          MIN="3.7"                                          # floor — ignore anything older
+          PIN="3.7 3.8 3.9 3.10 3.11 3.12 3.13 4.1"          # always built + fallback if discovery fails
+          DENY=""                                            # never build these
+          OVERRIDE="${{ inputs.versions }}"
 
+          MAXPIN=$(printf '%s\n' $PIN | sort -V | tail -1)
+          if [ -n "${OVERRIDE}" ]; then
+            CAND=$(echo "$OVERRIDE" | tr ', ' '\n' | grep -v '^$' || true)
+          else
+            DISCOVERED=$(docker run --rm gcr.io/go-containerregistry/crane ls "$UPSTREAM" 2>/dev/null \
+              | grep -E '^[0-9]+\.[0-9]+$' | sort -uV | paste -sd' ' - || true)
+            NEWER=""
+            for v in $DISCOVERED; do
+              [ "$v" = "$MAXPIN" ] && continue
+              [ "$(printf '%s\n%s\n' "$MAXPIN" "$v" | sort -V | tail -1)" = "$v" ] && NEWER="$NEWER $v"
+            done
+            CAND="$PIN $NEWER"
+          fi
+
+          SEL=""
+          for v in $CAND; do
+            case " $DENY " in *" $v "*) continue ;; esac
+            [ "$(printf '%s\n%s\n' "$MIN" "$v" | sort -V | head -n1)" = "$MIN" ] || continue
+            SEL="$SEL $v"
+          done
+          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV)
+          echo "Selected RabbitMQ versions: $(echo $SEL | paste -sd' ' -)"
+
+          if [ -z "$(echo $SEL | tr -d '[:space:]')" ]; then
+            echo 'matrix={"version":[]}' >> "$GITHUB_OUTPUT"
+            echo 'build=false' >> "$GITHUB_OUTPUT"
+          else
+            MATRIX=$(printf '%s\n' $SEL | jq -R . | jq -cs '{version: .}')
+            echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+            echo 'build=true' >> "$GITHUB_OUTPUT"
+          fi
+
+  rabbitmq:
+    name: RabbitMQ ${{ matrix.version }}
+    needs: discover
+    if: needs.discover.outputs.build == 'true'
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        version:
-          - "3.7"
-          - "3.8"
-          - "3.9"
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-          - "4.1"
-#        include:
-#          - version: "3.12"
-#            modifier: "-rc"
-
+      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
@@ -43,18 +88,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ !env.ACT }}
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-        if: ${{ !env.ACT }}
-
       - uses: docker/build-push-action@v6
         with:
           context: rabbitmq
           platforms: linux/amd64,linux/arm64
-          build-args: RABBITMQ_VERSION=${{ matrix.version }}${{ matrix.modifier }}
+          build-args: RABBITMQ_VERSION=${{ matrix.version }}
           push: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
-          tags: ghcr.io/${{ github.repository_owner }}/roll/rabbitmq:${{ matrix.version }}${{ matrix.modifier }}
+          tags: ghcr.io/${{ github.repository_owner }}/roll/rabbitmq:${{ matrix.version }}
         if: ${{ !env.ACT && github.ref == 'refs/heads/master'}}

--- a/.github/workflows/docker-image-redis.yml
+++ b/.github/workflows/docker-image-redis.yml
@@ -95,4 +95,4 @@ jobs:
           build-args: REDIS_VERSION=${{ matrix.version }}
           push: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
           tags: ghcr.io/${{ github.repository_owner }}/roll/redis:${{ matrix.version }}
-        if: ${{ !env.ACT && github.ref == 'refs/heads/master'}}
+        if: ${{ !env.ACT }}

--- a/.github/workflows/docker-image-redis.yml
+++ b/.github/workflows/docker-image-redis.yml
@@ -55,7 +55,7 @@ jobs:
             [ "$(printf '%s\n%s\n' "$MIN" "$v" | sort -V | head -n1)" = "$MIN" ] || continue
             SEL="$SEL $v"
           done
-          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV)
+          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV || true)
           echo "Selected Redis versions: $(echo $SEL | paste -sd' ' -)"
 
           if [ -z "$(echo $SEL | tr -d '[:space:]')" ]; then

--- a/.github/workflows/docker-image-redis.yml
+++ b/.github/workflows/docker-image-redis.yml
@@ -1,6 +1,11 @@
 name: Docker Image Redis
 on:
   workflow_dispatch:
+    inputs:
+      versions:
+        description: 'Versions to build (comma-separated). Empty = auto-discover.'
+        required: false
+        type: string
   schedule:
     - cron: "0 6 * * *" # 6 AM Daily
   push:
@@ -10,24 +15,66 @@ on:
       - .github/workflows/*redis*
 
 jobs:
-  redis:
-    name: Redis
+  # Discover which versions to build: the pinned list is always built and any
+  # upstream version newer than the highest pinned one is added automatically.
+  # Edit PIN to curate, DENY to exclude, MIN for the floor. See README.
+  discover:
+    name: Discover Redis versions
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.discover.outputs.matrix }}
+      build: ${{ steps.discover.outputs.build }}
+    steps:
+      - name: Discover versions
+        id: discover
+        run: |
+          set -uo pipefail
+          UPSTREAM="redis"
+          MIN="5.0"                       # floor — ignore anything older
+          PIN="5.0 6.0 6.2 7.0 7.2"       # always built + fallback if discovery fails
+          DENY=""                         # never build these
+          OVERRIDE="${{ inputs.versions }}"
 
+          MAXPIN=$(printf '%s\n' $PIN | sort -V | tail -1)
+          if [ -n "${OVERRIDE}" ]; then
+            CAND=$(echo "$OVERRIDE" | tr ', ' '\n' | grep -v '^$' || true)
+          else
+            DISCOVERED=$(docker run --rm gcr.io/go-containerregistry/crane ls "$UPSTREAM" 2>/dev/null \
+              | grep -E '^[0-9]+\.[0-9]+$' | sort -uV | paste -sd' ' - || true)
+            NEWER=""
+            for v in $DISCOVERED; do
+              [ "$v" = "$MAXPIN" ] && continue
+              [ "$(printf '%s\n%s\n' "$MAXPIN" "$v" | sort -V | tail -1)" = "$v" ] && NEWER="$NEWER $v"
+            done
+            CAND="$PIN $NEWER"
+          fi
+
+          SEL=""
+          for v in $CAND; do
+            case " $DENY " in *" $v "*) continue ;; esac
+            [ "$(printf '%s\n%s\n' "$MIN" "$v" | sort -V | head -n1)" = "$MIN" ] || continue
+            SEL="$SEL $v"
+          done
+          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV)
+          echo "Selected Redis versions: $(echo $SEL | paste -sd' ' -)"
+
+          if [ -z "$(echo $SEL | tr -d '[:space:]')" ]; then
+            echo 'matrix={"version":[]}' >> "$GITHUB_OUTPUT"
+            echo 'build=false' >> "$GITHUB_OUTPUT"
+          else
+            MATRIX=$(printf '%s\n' $SEL | jq -R . | jq -cs '{version: .}')
+            echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+            echo 'build=true' >> "$GITHUB_OUTPUT"
+          fi
+
+  redis:
+    name: Redis ${{ matrix.version }}
+    needs: discover
+    if: needs.discover.outputs.build == 'true'
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        version:
-          - "5.0"
-          - "6.0"
-          - "6.2"
-          - "7.0"
-          - "7.2"
-#        include:
-#          - version: "7.2"
-#            modifier: "-rc"
-
-
+      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
@@ -41,18 +88,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ !env.ACT }}
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-        if: ${{ !env.ACT }}
-
       - uses: docker/build-push-action@v6
         with:
           context: redis
           platforms: linux/amd64,linux/arm64
-          build-args: REDIS_VERSION=${{ matrix.version }}${{ matrix.modifier }}
+          build-args: REDIS_VERSION=${{ matrix.version }}
           push: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
-          tags: ghcr.io/${{ github.repository_owner }}/roll/redis:${{ matrix.version }}${{ matrix.modifier }}
+          tags: ghcr.io/${{ github.repository_owner }}/roll/redis:${{ matrix.version }}
         if: ${{ !env.ACT && github.ref == 'refs/heads/master'}}

--- a/.github/workflows/docker-image-startpage.yml
+++ b/.github/workflows/docker-image-startpage.yml
@@ -33,4 +33,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
           tags: ghcr.io/${{ github.repository_owner }}/roll/startpage:latest
-        if: ${{ !env.ACT && github.ref == 'refs/heads/master'}}
+        if: ${{ !env.ACT }}

--- a/.github/workflows/docker-image-startpage.yml
+++ b/.github/workflows/docker-image-startpage.yml
@@ -27,13 +27,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ !env.ACT }}
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-        if: ${{ !env.ACT }}
-
       - uses: docker/build-push-action@v6
         with:
           context: startpage

--- a/.github/workflows/docker-image-varnish.yml
+++ b/.github/workflows/docker-image-varnish.yml
@@ -1,32 +1,81 @@
 name: Docker Image Varnish
 on:
   workflow_dispatch:
+    inputs:
+      versions:
+        description: 'Versions (major.minor, comma-separated). Empty = auto-discover.'
+        required: false
+        type: string
   schedule:
     - cron: "0 6 * * *" # 6 AM Daily
   push:
     paths:
+      - .trigger
       - varnish/**
       - .github/workflows/docker-image-varnish.yml
 
 jobs:
-  varnish:
-    name: Varnish
+  # Discover which versions to build: the pinned list is always built and any
+  # upstream major.minor newer than the highest pinned one is added automatically.
+  # The major.minor is resolved to its latest patch at build time below.
+  # Edit PIN to curate, DENY to exclude, MIN for the floor. See README.
+  discover:
+    name: Discover Varnish versions
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.discover.outputs.matrix }}
+      build: ${{ steps.discover.outputs.build }}
+    steps:
+      - name: Discover versions
+        id: discover
+        run: |
+          set -uo pipefail
+          UPSTREAM="varnish"
+          MIN="6.6"                                       # floor — ignore anything older (6.0 LTS handled separately)
+          PIN="6.6 7.0 7.1 7.2 7.3 7.4 7.5 7.6 7.7"       # always built + fallback if discovery fails
+          DENY=""                                         # never build these
+          OVERRIDE="${{ inputs.versions }}"
 
+          MAXPIN=$(printf '%s\n' $PIN | sort -V | tail -1)
+          if [ -n "${OVERRIDE}" ]; then
+            CAND=$(echo "$OVERRIDE" | tr ', ' '\n' | grep -v '^$' || true)
+          else
+            DISCOVERED=$(docker run --rm gcr.io/go-containerregistry/crane ls "$UPSTREAM" 2>/dev/null \
+              | grep -E '^[0-9]+\.[0-9]+$' | sort -uV | paste -sd' ' - || true)
+            NEWER=""
+            for v in $DISCOVERED; do
+              [ "$v" = "$MAXPIN" ] && continue
+              [ "$(printf '%s\n%s\n' "$MAXPIN" "$v" | sort -V | tail -1)" = "$v" ] && NEWER="$NEWER $v"
+            done
+            CAND="$PIN $NEWER"
+          fi
+
+          SEL=""
+          for v in $CAND; do
+            case " $DENY " in *" $v "*) continue ;; esac
+            [ "$(printf '%s\n%s\n' "$MIN" "$v" | sort -V | head -n1)" = "$MIN" ] || continue
+            SEL="$SEL $v"
+          done
+          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV)
+          echo "Selected Varnish versions: $(echo $SEL | paste -sd' ' -)"
+
+          if [ -z "$(echo $SEL | tr -d '[:space:]')" ]; then
+            echo 'matrix={"version":[]}' >> "$GITHUB_OUTPUT"
+            echo 'build=false' >> "$GITHUB_OUTPUT"
+          else
+            MATRIX=$(printf '%s\n' $SEL | jq -R . | jq -cs '{version: .}')
+            echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+            echo 'build=true' >> "$GITHUB_OUTPUT"
+          fi
+
+  varnish:
+    name: Varnish ${{ matrix.version }}
+    needs: discover
+    if: needs.discover.outputs.build == 'true'
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        version:
-          - "6.6"
-          - "7.0"
-          - "7.1"
-          - "7.2"
-          - "7.3"
-          - "7.4"
-          - "7.5"
-          - "7.6"
-          - "7.7"
-
+      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
@@ -38,13 +87,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ !env.ACT }}
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
         if: ${{ !env.ACT }}
 
       - name: Determine Version
@@ -64,6 +106,7 @@ jobs:
           push: ${{ github.ref == 'refs/heads/master' && !env.ACT }}
           tags: ghcr.io/${{ github.repository_owner }}/roll/varnish:${{ matrix.version }}
 
+  # 6.0 is the long-term-support line and uses a dedicated Dockerfile; kept fixed.
   varnish-lts:
     name: Varnish LTS
     runs-on: ubuntu-latest
@@ -85,13 +128,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ !env.ACT }}
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
         if: ${{ !env.ACT }}
 
       - name: Determine Version

--- a/.github/workflows/docker-image-varnish.yml
+++ b/.github/workflows/docker-image-varnish.yml
@@ -56,7 +56,7 @@ jobs:
             [ "$(printf '%s\n%s\n' "$MIN" "$v" | sort -V | head -n1)" = "$MIN" ] || continue
             SEL="$SEL $v"
           done
-          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV)
+          SEL=$(printf '%s\n' $SEL | grep -v '^$' | sort -uV || true)
           echo "Selected Varnish versions: $(echo $SEL | paste -sd' ' -)"
 
           if [ -z "$(echo $SEL | tr -d '[:space:]')" ]; then

--- a/.github/workflows/mirror-base-images.yml
+++ b/.github/workflows/mirror-base-images.yml
@@ -59,12 +59,16 @@ jobs:
               || echo "::warning::failed to mirror $src -> $dst"
           }
 
-          echo "── PHP (major.minor -fpm- bullseye/bookworm, >= 7.4) ──"
+          # Floor MUST stay <= php-fpm's PHP_MIN_VERSION (php-matrix/constants.php).
+          # php-fpm switches ENV_SOURCE_IMAGE to this mirror for every PHP version
+          # it builds, so any version it builds (currently down to 7.3) must be
+          # mirrored here or that build would fail to pull its base.
+          PHP_FLOOR="7.3"
+          echo "── PHP (major.minor -fpm- bullseye/bookworm, >= ${PHP_FLOOR}) ──"
           for tag in $(crane ls php 2>/dev/null \
               | grep -E '^[0-9]+\.[0-9]+-fpm-(bullseye|bookworm)$' | sort -uV); do
             ver=${tag%%-*}
-            # floor 7.4
-            [ "$(printf '7.4\n%s\n' "$ver" | sort -V | head -n1)" = "7.4" ] || continue
+            [ "$(printf '%s\n%s\n' "$PHP_FLOOR" "$ver" | sort -V | head -n1)" = "$PHP_FLOOR" ] || continue
             mirror "php:${tag}" "${BASE}/php:${tag}"
           done
 

--- a/.github/workflows/mirror-base-images.yml
+++ b/.github/workflows/mirror-base-images.yml
@@ -1,0 +1,87 @@
+name: Mirror Base Images
+
+# Mirrors the upstream base images that php-fpm builds FROM (php, node, composer,
+# phantomjs) into the GHCR namespace `ghcr.io/<owner>/base-images/*`. This
+# insulates the heavy php-fpm matrix from Docker Hub pull-rate limits / outages —
+# a common source of transient build failures.
+#
+# It is OPTIONAL: the php-fpm workflow's `discover` job uses the mirror when it
+# exists and transparently falls back to Docker Hub when it does not. Run this
+# once (workflow_dispatch) to populate the mirror, after which the weekly
+# schedule keeps it fresh.
+
+on:
+  workflow_dispatch:
+    inputs:
+      force_mirror:
+        description: 'Re-copy even if the target tag already exists'
+        required: false
+        type: boolean
+        default: false
+  schedule:
+    # Weekly, Sunday 01:00 UTC — ahead of the daily php-fpm build.
+    - cron: '0 1 * * 0'
+
+jobs:
+  mirror:
+    name: Mirror upstream base images to GHCR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: imjasonh/setup-crane@v0.4
+
+      - name: Login to GHCR
+        if: ${{ !env.ACT }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Mirror images
+        run: |
+          set -uo pipefail
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          BASE="ghcr.io/${OWNER}/base-images"
+          FORCE="${{ inputs.force_mirror }}"
+
+          # copy SRC -> DST unless DST already exists (and not forcing).
+          mirror() {
+            local src="$1" dst="$2"
+            if [ "$FORCE" != "true" ] && crane manifest "$dst" >/dev/null 2>&1; then
+              echo "✓ already mirrored: $dst"
+              return 0
+            fi
+            echo "🔄 $src -> $dst"
+            crane copy "$src" "$dst" && echo "✅ mirrored $dst" \
+              || echo "::warning::failed to mirror $src -> $dst"
+          }
+
+          echo "── PHP (major.minor -fpm- bullseye/bookworm, >= 7.4) ──"
+          for tag in $(crane ls php 2>/dev/null \
+              | grep -E '^[0-9]+\.[0-9]+-fpm-(bullseye|bookworm)$' | sort -uV); do
+            ver=${tag%%-*}
+            # floor 7.4
+            [ "$(printf '7.4\n%s\n' "$ver" | sort -V | head -n1)" = "7.4" ] || continue
+            mirror "php:${tag}" "${BASE}/php:${tag}"
+          done
+
+          echo "── Node (major -bullseye/bookworm, >= 14) ──"
+          for tag in $(crane ls node 2>/dev/null \
+              | grep -E '^[0-9]+-(bullseye|bookworm)$' | sort -uV); do
+            ver=${tag%%-*}
+            [ "$ver" -ge 14 ] 2>/dev/null || continue
+            mirror "node:${tag}" "${BASE}/node:${tag}"
+          done
+
+          echo "── Composer ──"
+          for tag in 1 2 2.2; do
+            mirror "composer:${tag}" "${BASE}/composer:${tag}"
+          done
+
+          echo "── PhantomJS ──"
+          mirror "99designs/phantomjs:2.1.1" "${BASE}/phantomjs:2.1.1"
+
+          echo "Done. Mirror namespace: ${BASE}/*"

--- a/.github/workflows/php-matrix/constants.php
+++ b/.github/workflows/php-matrix/constants.php
@@ -108,6 +108,14 @@ function resolve_versions(string $envVar, array $pin, array $deny, string $min):
         ? preg_split('/[\s,]+/', trim($raw), -1, PREG_SPLIT_NO_EMPTY)
         : [];
 
+    // Only accept well-formed numeric versions (e.g. "8", "8.4", "8.0.28"). This
+    // drops stray text or pre-release suffixes (e.g. "8.4-rc") from the discovered
+    // list / dispatch override before they reach version sorting and the matrix.
+    $discovered = array_filter(
+        $discovered,
+        static fn($v) => preg_match('/^\d+(\.\d+)*$/', $v) === 1
+    );
+
     // Discovery only ADDS versions newer than the highest pinned one, so
     // intentionally-skipped older minors are never back-filled (this matches the
     // documented policy and the simple-service workflows). The pins themselves are

--- a/.github/workflows/php-matrix/constants.php
+++ b/.github/workflows/php-matrix/constants.php
@@ -108,6 +108,23 @@ function resolve_versions(string $envVar, array $pin, array $deny, string $min):
         ? preg_split('/[\s,]+/', trim($raw), -1, PREG_SPLIT_NO_EMPTY)
         : [];
 
+    // Discovery only ADDS versions newer than the highest pinned one, so
+    // intentionally-skipped older minors are never back-filled (this matches the
+    // documented policy and the simple-service workflows). The pins themselves are
+    // always kept. With no pins, every discovered version above the floor is used.
+    $maxPin = null;
+    foreach ($pin as $p) {
+        if ($maxPin === null || version_compare($p, $maxPin, '>')) {
+            $maxPin = $p;
+        }
+    }
+    if ($maxPin !== null) {
+        $discovered = array_filter(
+            $discovered,
+            static fn($v) => version_compare($v, $maxPin, '>')
+        );
+    }
+
     $versions = array_merge($pin, $discovered);
 
     $versions = array_filter($versions, static function ($v) use ($deny, $min) {

--- a/.github/workflows/php-matrix/constants.php
+++ b/.github/workflows/php-matrix/constants.php
@@ -1,5 +1,35 @@
 <?php
 
+// =============================================================================
+// Version configuration for the php-fpm image matrix.
+//
+// PHP and Node versions are normally DISCOVERED automatically from the upstream
+// registry by the workflow (see docker-image-php-fpm.yml — the "discover" job
+// lists the available `php` / `node` tags with crane and passes them to the
+// generators via the DISCOVERED_PHP_VERSIONS / DISCOVERED_NODE_VERSIONS env
+// vars). This file is the OVERRIDE / CONTROL layer applied on top of discovery:
+//
+//   *_MIN_VERSION   Floor — discovery (and the fallback list) ignore anything
+//                   older than this.
+//   *_DENY_VERSIONS Never build these, even if upstream still publishes them.
+//   *_PIN_VERSIONS  Always build these AND use them as the static fallback when
+//                   discovery is unavailable (running the generators locally, or
+//                   the registry being unreachable in CI).
+//   *_OS_RELEASE    Pin the Debian base (bullseye/bookworm/…) for a version.
+//                   This map is authoritative; a version not listed defaults to
+//                   bullseye.
+//   EOL / EXPERIMENTAL / xdebug   Per-version build flags.
+//
+// HOW TO ADD OR CHANGE A VERSION (see README.md → "Adding or changing a version")
+//   * Add a version:    usually nothing — it is picked up automatically once it
+//                       appears upstream above the floor. To guarantee it builds
+//                       regardless of discovery, add it to the relevant *_PIN.
+//   * Stop building one: add it to the relevant *_DENY (or raise the floor).
+//   * Change its Debian base: set it in *_OS_RELEASE.
+//   * Mark it EOL / experimental: add it to the matching list below so a flaky
+//                       build of it can't fail the run (continue-on-error).
+// =============================================================================
+
 const ARCHES = [
     [
         'name' => 'x86',
@@ -19,8 +49,18 @@ const ARCHES = [
     ],
 ];
 
-const PHP_LATEST = '8.4';
-const PHP_VERSIONS = ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4'];
+// ---- PHP --------------------------------------------------------------------
+const PHP_MIN_VERSION = '7.3';
+const PHP_DENY_VERSIONS = [];
+// Built unconditionally + fallback list when discovery is unavailable.
+const PHP_PIN_VERSIONS = ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4'];
+
+// ---- Node -------------------------------------------------------------------
+const NODE_MIN_VERSION = '10';
+const NODE_DENY_VERSIONS = [];
+const NODE_PIN_VERSIONS = ['10', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22'];
+
+// ---- Debian base pinning (authoritative; overrides discovery) ---------------
 const PHP_VERSIONS_OS_RELEASE = [
     '7.3' => 'bullseye',
     '7.4' => 'bullseye',
@@ -30,11 +70,6 @@ const PHP_VERSIONS_OS_RELEASE = [
     '8.3' => 'bullseye',
     '8.4' => 'bullseye',
 ];
-const NODE_LATEST = '22';
-const NODE_VERSIONS = ['10', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22'];
-
-const EOL_NODE_VERSIONS = ['10', '12', '13', '14', '15', '16', '17', '19'];
-
 const NODE_VERSIONS_OS_RELEASE = [
     '10' => 'stretch',
     '12' => 'bullseye',
@@ -49,8 +84,71 @@ const NODE_VERSIONS_OS_RELEASE = [
     '21' => 'bullseye',
     '22' => 'bullseye',
 ];
-const EXPERIMENTAL_PHP_VERSIONS = [];
 
+// ---- Build flags ------------------------------------------------------------
+const EXPERIMENTAL_PHP_VERSIONS = [];
 const EOL_PHP_VERSIONS = ['7.3', '7.4'];
+const EOL_NODE_VERSIONS = ['10', '12', '13', '14', '15', '16', '17', '19'];
 const NOT_STABLE_XDEBUG_PHP_VERSIONS = ['7.3', '7.4'];
 
+/**
+ * Resolve the list of versions to build for one component (PHP or Node).
+ *
+ * Reads the discovered list from $envVar (comma / whitespace / newline
+ * separated). The pinned versions are always merged in, so when discovery is
+ * unavailable (the generators are run locally, or the registry could not be
+ * reached) the pinned list is what gets built. The deny-list and the version
+ * floor are then applied, and the result is de-duplicated and version-sorted
+ * ascending.
+ */
+function resolve_versions(string $envVar, array $pin, array $deny, string $min): array
+{
+    $raw = getenv($envVar);
+    $discovered = ($raw !== false && trim($raw) !== '')
+        ? preg_split('/[\s,]+/', trim($raw), -1, PREG_SPLIT_NO_EMPTY)
+        : [];
+
+    $versions = array_merge($pin, $discovered);
+
+    $versions = array_filter($versions, static function ($v) use ($deny, $min) {
+        if (in_array($v, $deny, true)) {
+            return false;
+        }
+        return version_compare($v, $min, '>=');
+    });
+
+    $versions = array_values(array_unique($versions));
+    usort($versions, 'version_compare');
+
+    return $versions;
+}
+
+/** The PHP versions to build (discovery ∪ pin, minus deny, above the floor). */
+function php_versions(): array
+{
+    return resolve_versions('DISCOVERED_PHP_VERSIONS', PHP_PIN_VERSIONS, PHP_DENY_VERSIONS, PHP_MIN_VERSION);
+}
+
+/** The Node versions to build (discovery ∪ pin, minus deny, above the floor). */
+function node_versions(): array
+{
+    return resolve_versions('DISCOVERED_NODE_VERSIONS', NODE_PIN_VERSIONS, NODE_DENY_VERSIONS, NODE_MIN_VERSION);
+}
+
+/** Highest version in a version-sorted list (used for the `latest` flag). */
+function latest_version(array $versions): string
+{
+    return empty($versions) ? '' : end($versions);
+}
+
+/** Debian base for a PHP version: pinned map wins, else bullseye. */
+function php_os_release(string $phpVersion): string
+{
+    return PHP_VERSIONS_OS_RELEASE[$phpVersion] ?? 'bullseye';
+}
+
+/** Debian base for a Node version: pinned map wins, else bullseye. */
+function node_os_release(string $nodeVersion): string
+{
+    return NODE_VERSIONS_OS_RELEASE[$nodeVersion] ?? 'bullseye';
+}

--- a/.github/workflows/php-matrix/constants.php
+++ b/.github/workflows/php-matrix/constants.php
@@ -53,7 +53,7 @@ const ARCHES = [
 const PHP_MIN_VERSION = '7.3';
 const PHP_DENY_VERSIONS = [];
 // Built unconditionally + fallback list when discovery is unavailable.
-const PHP_PIN_VERSIONS = ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4'];
+const PHP_PIN_VERSIONS = ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5'];
 
 // ---- Node -------------------------------------------------------------------
 const NODE_MIN_VERSION = '10';
@@ -69,6 +69,7 @@ const PHP_VERSIONS_OS_RELEASE = [
     '8.2' => 'bullseye',
     '8.3' => 'bullseye',
     '8.4' => 'bullseye',
+    '8.5' => 'bullseye',
 ];
 const NODE_VERSIONS_OS_RELEASE = [
     '10' => 'stretch',

--- a/.github/workflows/php-matrix/full-generator.php
+++ b/.github/workflows/php-matrix/full-generator.php
@@ -4,15 +4,25 @@ require_once(__DIR__ . DIRECTORY_SEPARATOR . 'constants.php');
 
 $matrix = [];
 
-foreach (PHP_VERSIONS as $phpVersion) {
+$phpVersions = php_versions();
+$nodeVersions = node_versions();
+$phpLatest = latest_version($phpVersions);
+$nodeLatest = latest_version($nodeVersions);
+
+foreach ($phpVersions as $phpVersion) {
     $xdebugType = !in_array($phpVersion, NOT_STABLE_XDEBUG_PHP_VERSIONS) ? 'xdebug-stable' : 'xdebug';
-    $phpOsRelease = array_key_exists($phpVersion, PHP_VERSIONS_OS_RELEASE) ? PHP_VERSIONS_OS_RELEASE[$phpVersion] : 'bullseye';
+    $phpOsRelease = php_os_release($phpVersion);
     $experimental = in_array($phpVersion, EXPERIMENTAL_PHP_VERSIONS);
-    $endOfLife = in_array($phpVersion, EOL_PHP_VERSIONS);
+    $phpEndOfLife = in_array($phpVersion, EOL_PHP_VERSIONS);
     foreach (ARCHES as $arch) {
-        foreach (NODE_VERSIONS as $nodeVersion) {
-            $nodeOsRelease = array_key_exists($nodeVersion, NODE_VERSIONS_OS_RELEASE) ? NODE_VERSIONS_OS_RELEASE[$nodeVersion] : 'bullseye';
-            $endOfLife = in_array($nodeVersion, EOL_NODE_VERSIONS);
+        foreach ($nodeVersions as $nodeVersion) {
+            $nodeOsRelease = node_os_release($nodeVersion);
+            // A combination is end-of-life if EITHER its PHP or its Node version
+            // is EOL. Previously the PHP flag was overwritten by the Node flag,
+            // so an EOL PHP paired with a supported Node (e.g. 7.3 + node21) was
+            // wrongly marked non-EOL → continue_on_error=false → one flaky build
+            // could fail the whole matrix and block publishing.
+            $endOfLife = $phpEndOfLife || in_array($nodeVersion, EOL_NODE_VERSIONS);
             $matrix[] = [
                 'php_version' => $phpVersion,
                 'php_os_release' => $phpOsRelease,
@@ -22,7 +32,7 @@ foreach (PHP_VERSIONS as $phpVersion) {
                 'experimental' => $experimental,
                 'end_of_life' => $endOfLife,
                 'continue_on_error' => $endOfLife || $experimental,
-                'latest' => $phpVersion === PHP_LATEST && $nodeVersion === NODE_LATEST,
+                'latest' => $phpVersion === $phpLatest && $nodeVersion === $nodeLatest,
                 'arch' => $arch,
             ];
         }

--- a/.github/workflows/php-matrix/node-generator.php
+++ b/.github/workflows/php-matrix/node-generator.php
@@ -4,11 +4,11 @@ require_once(__DIR__ . DIRECTORY_SEPARATOR . 'constants.php');
 
 $matrix = [];
 
-foreach (PHP_VERSIONS as $phpVersion) {
+foreach (php_versions() as $phpVersion) {
     $experimental = in_array($phpVersion, EXPERIMENTAL_PHP_VERSIONS);
-    $phpOsRelease = array_key_exists($phpVersion, PHP_VERSIONS_OS_RELEASE) ? PHP_VERSIONS_OS_RELEASE[$phpVersion] : 'bullseye';
-    foreach (NODE_VERSIONS as $nodeVersion) {
-        $nodeOsRelease = array_key_exists($nodeVersion, NODE_VERSIONS_OS_RELEASE) ? NODE_VERSIONS_OS_RELEASE[$nodeVersion] : 'bullseye';
+    $phpOsRelease = php_os_release($phpVersion);
+    foreach (node_versions() as $nodeVersion) {
+        $nodeOsRelease = node_os_release($nodeVersion);
         foreach (ARCHES as $arch) {
             $matrix[] = [
                 'php_version' => $phpVersion,

--- a/.github/workflows/php-matrix/php-generator.php
+++ b/.github/workflows/php-matrix/php-generator.php
@@ -4,9 +4,9 @@ require_once(__DIR__ . DIRECTORY_SEPARATOR . 'constants.php');
 
 $matrix = [];
 
-foreach (PHP_VERSIONS as $phpVersion) {
+foreach (php_versions() as $phpVersion) {
     $experimental = in_array($phpVersion, EXPERIMENTAL_PHP_VERSIONS);
-    $phpOsRelease = array_key_exists($phpVersion, PHP_VERSIONS_OS_RELEASE) ? PHP_VERSIONS_OS_RELEASE[$phpVersion] : 'bullseye';
+    $phpOsRelease = php_os_release($phpVersion);
 
     foreach (ARCHES as $arch) {
         $matrix[] = [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,8 @@ PHP — which is why this repo's images and the nginx vhost templates
 There is no application code here — each top-level directory is one service image
 (its `Dockerfile` plus supporting config), and each has a matching GitHub Actions
 workflow that builds it for `linux/amd64` + `linux/arm64` and publishes it to
-`ghcr.io/epartment/roll/<name>`. (Workflows also log in to Docker Hub, but no
-`docker.io` image tags are currently created — only GHCR is pushed.)
+`ghcr.io/epartment/roll/<name>`. Only GHCR is pushed (the old Docker Hub login/tags
+have been removed).
 
 Services: `php-fpm` (the complex one — see below), `nginx`, `varnish`,
 `mariadb`, `mysql`, `mongo`, `redis`, `dragonfly`, `elasticsearch`, `opensearch`,
@@ -32,6 +32,21 @@ by `.github/workflows/docker-image-*.yml`. Each workflow triggers on:
 
 Images are only pushed when `github.ref == 'refs/heads/master'` (and not under
 `act`). On other branches/PRs the workflow runs the build but skips the push.
+
+Every workflow has a two-stage shape: a **`discover`** job decides which versions to
+build, then a **build matrix** builds each version as an independent job. `fail-fast:
+false` is set everywhere, so one version failing never stops the others.
+
+**Robustness invariants to preserve when editing workflows:**
+- Build-matrix jobs are independent (`fail-fast: false`) — never introduce a shared
+  failure point across versions.
+- php-fpm `merge-*` jobs run with `if: ${{ !cancelled() && ... }}` and publish only
+  versions that have **both** arch digests (`EXPECTED_ARCHES=2`), skipping incomplete
+  ones rather than failing. This is what stops one flaky combination from blocking
+  every tag — don't revert it to a plain `needs:`-gated merge.
+- EOL/experimental combinations are `continue-on-error` (see `constants.php`).
+- In-Dockerfile downloads use `curl --retry` / retry loops, not bare `ADD <url>` or a
+  single `composer require`/`npm install`.
 
 **`.trigger`** at the repo root is a no-op file listed in the `paths:` of many
 workflows. Editing it (e.g. changing the UUID) is the way to force a rebuild of
@@ -64,28 +79,50 @@ stage's registry image as `ENV_SOURCE_IMAGE` so layers stack. Version-conditiona
 logic inside the Dockerfiles is done with shell `sort -g`/`sort -V` comparisons on
 `${PHP_VERSION}` (e.g. "install imagick only if PHP > 7.2 && < 8.3").
 
-### Version matrix is generated, not hand-written
+### Version matrix is discovered + generated, not hard-coded
 
-`docker-image-php-fpm.yml` does not hard-code versions. Three PHP scripts in
-`.github/workflows/php-matrix/` emit the GitHub Actions matrix JSON:
+`docker-image-php-fpm.yml` does not hard-code versions. Its **`discover`** job lists
+the upstream `php`/`node` tags with crane (preferring the GHCR `base-images` mirror,
+falling back to Docker Hub) and passes them to three PHP generator scripts in
+`.github/workflows/php-matrix/` via the `DISCOVERED_PHP_VERSIONS` /
+`DISCOVERED_NODE_VERSIONS` env vars. The generators emit the GitHub Actions matrix
+JSON (one entry per PHP × Node × arch):
 
-- `constants.php` — **single source of truth**: `PHP_VERSIONS`, `NODE_VERSIONS`,
-  per-version Debian `OS_RELEASE`, EOL/experimental lists, and the `ARCHES`
-  (amd64 / arm64 runner definitions). **Edit this to add/drop a PHP or Node version.**
+- `constants.php` — the **policy / single source of truth**: floor (`*_MIN_VERSION`),
+  always-build + fallback (`*_PIN_VERSIONS`), exclude (`*_DENY_VERSIONS`), per-version
+  Debian `OS_RELEASE` maps, EOL/experimental/xdebug lists, and `ARCHES`. The
+  `php_versions()` / `node_versions()` helpers resolve discovered ∪ pinned − deny,
+  above the floor. **Edit this to add/pin/exclude a PHP or Node version** (see the
+  file header and README → "Adding or changing a version").
 - `php-generator.php` — base PHP × arch (for the base php-fpm build).
 - `node-generator.php` — PHP × Node × arch (for the +node layer).
 - `full-generator.php` — PHP × Node × arch with xdebug/EOL/`latest` flags (for the
   Magento/WordPress/xdebug layers).
 
+Run a generator locally to preview the matrix (it falls back to the pinned lists when
+the `DISCOVERED_*` env vars are unset):
+`php .github/workflows/php-matrix/full-generator.php | sed 's/^matrix=//' | jq`.
+
+The simple per-service workflows use the same floor/pin/deny policy, but inline as
+shell variables (`MIN` / `PIN` / `DENY`) in their own `discover` job, plus a
+`versions` `workflow_dispatch` input for ad-hoc builds.
+
 ### Multi-arch via digest + manifest merge
 
 Each layer is built **per-architecture separately** (on native amd64 and arm64
-runners), pushed `push-by-digest=true` (no tag), and the digest uploaded as an
-artifact. Separate `merge*` jobs then download all digests for a given image,
+runners — no QEMU), pushed `push-by-digest=true` (no tag), and the digest uploaded as
+an artifact. Separate `merge*` jobs then download all digests for a given image,
 group them by PHP version, and run `docker buildx imagetools create` to assemble
-the multi-arch manifest tagged `:<php_version>`. No `latest` tag is created. When
+the multi-arch manifest tagged `:<php_version>`. A version is published **only when
+both arch digests are present** (incomplete ones are skipped, keeping their previous
+image); the merge runs even if some builds failed. No `latest` tag is created. When
 adding a new layered image, you must add both a build job (emitting digests) and a
 matching `merge-*` job (assembling the manifest) — they go together.
+
+There is also an optional `mirror-base-images.yml` workflow that mirrors the upstream
+bases (`php`/`node`/`composer`/`phantomjs`) into `ghcr.io/<owner>/base-images/*` to
+insulate builds from Docker Hub rate limits; php-fpm's `discover` uses it when present
+and falls back to Docker Hub otherwise.
 
 ## Runtime behaviour of php-fpm images
 
@@ -102,8 +139,10 @@ intact when editing the entrypoint.
 ## Conventions
 
 - Image tags are the upstream version string (`redis:7.2`, `php-fpm-magento2:8.3`),
-  driven by each workflow's `matrix.version`. Simple services hard-code the version
-  list in the workflow `strategy.matrix`; only php-fpm uses generated matrices.
+  driven by each workflow's `matrix.version`. Every service now derives its matrix
+  from a `discover` job (floor/pin/deny policy); php-fpm additionally runs the
+  `php-matrix` generators. No service hard-codes its full version list anymore
+  (legacy fixed jobs like `mysql-legacy` / `varnish-lts` are the exception).
 - Registry owner comes from `github.repository_owner` (so forks publish under their
   own namespace) — env blocks that say `ghcr.io/epartment/...` are the canonical
   upstream targets.

--- a/README.md
+++ b/README.md
@@ -13,45 +13,84 @@ There is no application code here — each top-level directory is one service im
 workflow that builds it for `linux/amd64` + `linux/arm64` and publishes it to the
 GitHub Container Registry.
 
+> **New here?** Jump to [How builds work](#how-builds-work) for the big picture, or
+> [Adding or changing a version](#adding-or-changing-a-version) if you just need to
+> get a new version building.
+
 ## Images
 
 All images are published to `ghcr.io/<owner>/roll/<name>:<version>`. The canonical
 upstream namespace is **`ghcr.io/epartment/roll/`**; forks publish under their own
 owner automatically (the namespace is derived from `github.repository_owner`).
 
-| Image | Tags (versions) |
+| Image | Versions |
 | --- | --- |
-| `php-fpm` | see [PHP-FPM image graph](#php-fpm-the-layered-image-graph) |
-| `php-fpm-debug`, `php-fpm-magento1`, `php-fpm-magento2`, `php-fpm-magento2-debug`, `php-fpm-wordpress` | per PHP version |
-| `nginx` | `1.16`, `1.25`, `1.26`, `1.27` |
-| `varnish` | `6.0` (legacy/lts), `6.6`, `7.0`–`7.7` |
-| `mariadb` | `10.3`, `10.4`, `10.6`, `11.3`, `11.4` |
-| `mysql` | `5.5`, `5.6`, `5.7`, `8.0`–`8.4`, `9.0`–`9.2` |
-| `mongo` | `5`, `6`, `7` |
-| `redis` | `5.0`, `6.0`, `6.2`, `7.0`, `7.2` |
-| `dragonfly` | `1.3`–`1.17` |
-| `elasticsearch` | `7.17`, `8.4`, `8.6`, `8.11`–`8.13` |
-| `opensearch` | `2.9`–`2.13`, `2.19`, `3.1`–`3.3` |
-| `rabbitmq` | `3.7`–`3.13`, `4.1` |
+| `php-fpm` and its variants (`php-fpm-debug`, `php-fpm-magento1`, `php-fpm-magento2`, `php-fpm-magento2-debug`, `php-fpm-wordpress`) | per PHP × Node combination — see [the PHP-FPM image graph](#php-fpm-the-layered-image-graph) |
+| `nginx` | `1.16`, `1.25`, `1.26`, `1.27` + newer (auto) |
+| `varnish` | `6.0` (LTS), `6.6`, `7.0`–`7.7` + newer (auto) |
+| `mariadb` | `10.3`, `10.4`, `10.6`, `11.3`, `11.4` + newer (auto) |
+| `mysql` | `5.5`–`5.7` (legacy), `8.0`–`8.4`, `9.0`–`9.2` + newer (auto) |
+| `mongo` | `5`, `6`, `7` + newer (auto) |
+| `redis` | `5.0`, `6.0`, `6.2`, `7.0`, `7.2` + newer (auto) |
+| `dragonfly` | `1.3`–`1.17` + newer (auto) |
+| `elasticsearch` | `7.17`, `8.4`, `8.6`, `8.11`–`8.13` + newer (auto) |
+| `opensearch` | `2.9`–`2.13`, `2.19`, `3.1`–`3.3` + newer (auto) |
+| `rabbitmq` | `3.7`–`3.13`, `4.1` + newer (auto) |
 | `magepack` | `2.3`–`2.11` |
 | `mailhog`, `dnsmasq`, `startpage` | single image (no version matrix) |
 
-Image tags mirror the upstream version string. No `latest` tag is created.
+Image tags mirror the upstream version string. No `latest` tag is created for the
+service images. "**+ newer (auto)**" means the workflow **discovers** new upstream
+releases and starts building them on its own — see
+[Adding or changing a version](#adding-or-changing-a-version).
 
 ## How builds work
 
 **CI is the build system — there is no local build or test harness.** Images are
 built and published exclusively by `.github/workflows/docker-image-*.yml`. Each
-workflow triggers on:
+service workflow triggers on:
 
-- **`workflow_dispatch`** — manual run from the Actions tab,
+- **`workflow_dispatch`** — manual run from the Actions tab (most workflows accept a
+  `versions` input to build a specific set on demand),
 - a daily **`schedule`** cron (`0 6 * * *`) — so images rebuild against fresh
   upstream bases,
 - **`push`** touching that service's directory or its workflow file.
 
 Images are only **pushed** when running on `master` (`github.ref == 'refs/heads/master'`).
-On other branches and pull requests the workflow still builds the image to validate
-the change, but skips the registry push.
+On other branches and pull requests the workflow still runs to validate the change
+but skips the registry push.
+
+Every workflow has the same two-stage shape:
+
+```
+discover ──▶ build (matrix, one job per version, fail-fast: false)
+```
+
+1. A **`discover`** job lists the upstream tags and decides which versions to build
+   (see below).
+2. A **build matrix** builds each version as an independent job. Because
+   `fail-fast: false` is set everywhere, **one version failing never stops the
+   others** — each version succeeds or fails on its own.
+
+### Robustness: one failure can't block the rest
+
+This pipeline is designed so a single flaky build can never block publishing of
+everything else:
+
+- **Independent matrix jobs.** Every version is its own job with `fail-fast: false`,
+  so a transient failure (a slow download, a registry hiccup) is isolated to that
+  one version.
+- **Resilient multi-arch merge (php-fpm).** php-fpm builds each architecture
+  separately and then merges them into a multi-arch tag. The merge jobs run
+  **even if some builds failed** (`if: !cancelled()`), publish every version that
+  has *both* architectures, and **skip** any version missing an arch (it keeps its
+  previous image) instead of failing the whole run. Previously a single flaky
+  combination skipped the merge and blocked *every* php-fpm tag — that is fixed.
+- **EOL combinations are non-fatal.** End-of-life or experimental PHP/Node
+  combinations are marked `continue-on-error`, so a failure there can't fail the run.
+- **Network downloads retry.** In-Dockerfile downloads (the PHP extension installer,
+  magerun, wp-cli, `composer require`, `npm install`) use `curl --retry` / retry
+  loops instead of a single attempt that fails the build on one bad packet.
 
 ### Forcing a rebuild
 
@@ -64,6 +103,73 @@ that watches it, without having to touch a `Dockerfile`.
 - Push to a non-`master` branch and watch the workflow build (it won't push), or
 - Run a workflow locally with [`act`](https://github.com/nektos/act); the workflows
   detect `env.ACT` and skip registry logins and pushes.
+
+## Adding or changing a version
+
+Versions are **discovered automatically** from the upstream registry, on top of a
+small, explicit policy you control. The policy has the same shape everywhere:
+
+| Knob | Meaning |
+| --- | --- |
+| **floor** (`MIN`) | Ignore anything older than this. |
+| **pin** (`PIN`) | Always build these. Also the fallback list if discovery is unavailable. |
+| **deny** (`DENY`) | Never build these, even if upstream still publishes them. |
+
+The selection rule is: **build the pinned list, plus any upstream version newer than
+the highest pinned one**, minus the deny-list, above the floor. So:
+
+- A brand-new upstream release (newer than your newest pin) starts building **on its
+  own** — you usually do nothing.
+- Intentionally-skipped *older* minors are **not** back-filled (only versions newer
+  than your newest pin are auto-added), so curated lists stay curated.
+- To guarantee a specific version builds, **add it to the pin**. To stop building
+  one, **add it to the deny-list** (or raise the floor).
+
+### …for a simple service (redis, mysql, mariadb, mongo, nginx, elasticsearch, opensearch, varnish, dragonfly, rabbitmq)
+
+Edit the `discover` job at the top of that service's
+`.github/workflows/docker-image-<service>.yml`. The knobs are plain shell variables:
+
+```yaml
+MIN="5.0"                       # floor
+PIN="5.0 6.0 6.2 7.0 7.2"       # always build (+ fallback)
+DENY=""                         # never build
+```
+
+You can also build an ad-hoc set without editing anything: run the workflow from the
+Actions tab and fill in the **`versions`** input (e.g. `7.2, 7.4`).
+
+### …for php-fpm (PHP and Node)
+
+php-fpm has a richer matrix (PHP × Node × architecture × variant), so its policy
+lives in **[`.github/workflows/php-matrix/constants.php`](.github/workflows/php-matrix/constants.php)**
+instead of inline YAML:
+
+```php
+const PHP_MIN_VERSION  = '7.3';                  // floor
+const PHP_DENY_VERSIONS = [];                     // never build
+const PHP_PIN_VERSIONS  = ['7.3', ..., '8.4'];    // always build (+ fallback)
+// …and the same trio for Node (NODE_MIN_VERSION / NODE_DENY_VERSIONS / NODE_PIN_VERSIONS)
+```
+
+The same file also holds:
+
+- **`PHP_VERSIONS_OS_RELEASE` / `NODE_VERSIONS_OS_RELEASE`** — pin the Debian base
+  (`bullseye`/`bookworm`) for a version (a version not listed defaults to bullseye).
+- **`EOL_PHP_VERSIONS` / `EOL_NODE_VERSIONS` / `EXPERIMENTAL_PHP_VERSIONS`** — mark a
+  version so a flaky build of it can't fail the run (it becomes `continue-on-error`).
+- **`NOT_STABLE_XDEBUG_PHP_VERSIONS`** — which versions get the non-stable Xdebug.
+
+The three generator scripts (`php-generator.php`, `node-generator.php`,
+`full-generator.php`) read this config and emit the build matrix as JSON. You can run
+them locally to preview the matrix — no CI needed:
+
+```bash
+php .github/workflows/php-matrix/full-generator.php | sed 's/^matrix=//' | jq
+```
+
+To build a specific set on demand, run the **Docker Image PHP-FPM** workflow from the
+Actions tab and fill in the `php_versions` / `node_versions` inputs.
 
 ## PHP-FPM: the layered image graph
 
@@ -88,29 +194,31 @@ Version-conditional steps inside these Dockerfiles use shell `sort -g` / `sort -
 comparisons against `${PHP_VERSION}` (e.g. "install imagick only if PHP > 7.2 &&
 < 8.3").
 
-### The version matrix is generated, not hand-written
-
-`docker-image-php-fpm.yml` does not hard-code PHP/Node versions. Three PHP scripts
-in `.github/workflows/php-matrix/` emit the GitHub Actions matrix as JSON:
-
-- **`constants.php`** — the single source of truth: `PHP_VERSIONS`, `NODE_VERSIONS`,
-  per-version Debian `OS_RELEASE`, EOL/experimental lists, and the `ARCHES` (amd64 /
-  arm64 runner definitions). **Edit this to add or drop a PHP or Node version.**
-- `php-generator.php` — base PHP × arch (for the base php-fpm build).
-- `node-generator.php` — PHP × Node × arch (for the `+node` layer).
-- `full-generator.php` — PHP × Node × arch with xdebug/EOL/`latest` flags (for the
-  Magento / WordPress / xdebug layers).
-
 ### Multi-arch via digest + manifest merge
 
 Each layer is built **per-architecture separately** on native amd64 and arm64
-runners, pushed with `push-by-digest=true` (no tag), and the resulting digest is
-uploaded as a workflow artifact. Separate `merge-*` jobs then download all digests
-for a given image, group them by PHP version, and run `docker buildx imagetools
-create` to assemble the multi-arch manifest tagged `:<php_version>`.
+runners (no slow QEMU emulation), pushed with `push-by-digest=true` (no tag), and the
+resulting digest is uploaded as a workflow artifact. Separate `merge-*` jobs then
+download all digests for a given image, group them by version, and run
+`docker buildx imagetools create` to assemble the multi-arch manifest tagged
+`:<php_version>`. As described in [Robustness](#robustness-one-failure-cant-block-the-rest),
+a version is only published once **both** architectures are present.
 
 When adding a new layered image you must add **both** a build job (emitting digests)
 and a matching `merge-*` job (assembling the manifest) — they go together.
+
+### Base-image mirror (optional)
+
+[`mirror-base-images.yml`](.github/workflows/mirror-base-images.yml) copies the
+upstream bases php-fpm builds `FROM` (`php`, `node`, `composer`, `phantomjs`) into
+`ghcr.io/<owner>/base-images/*`. This insulates the heavy php-fpm matrix from Docker
+Hub pull-rate limits — a common cause of transient failures.
+
+It is **optional**: php-fpm's `discover` job uses the mirror when it exists and
+transparently falls back to Docker Hub when it doesn't. Run it once manually to
+populate the mirror; a weekly cron keeps it fresh. (Currently only the php base layer
+consumes the mirror; the node/composer/phantomjs layers still pull from Docker Hub —
+wiring those through the mirror is a possible follow-up.)
 
 ## Runtime behaviour of php-fpm images
 
@@ -139,8 +247,8 @@ php-fpm/            base + layered PHP-FPM images and the shared build context/
   node/ xdebug3/ magento1/ magento2/ wordpress/   layer Dockerfiles
 nginx/              nginx image + per-framework vhost templates (available.d/)
 varnish/ mariadb/ mysql/ mongo/ redis/ dragonfly/ ...   one directory per service
-.github/workflows/  one docker-image-*.yml per service
-.github/workflows/php-matrix/   PHP/Node version matrix generators
+.github/workflows/  one docker-image-*.yml per service + mirror-base-images.yml
+.github/workflows/php-matrix/   php-fpm version policy (constants.php) + matrix generators
 .trigger            no-op file; bump to force a rebuild
 ```
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ service workflow triggers on:
 - **`push`** touching that service's directory or its workflow file.
 
 Images are only **pushed** when running on `master` (`github.ref == 'refs/heads/master'`).
-On other branches and pull requests the workflow still runs to validate the change
-but skips the registry push.
+On other branches the service workflows still **build** the image to validate the
+change and skip only the push. (The lone exception is `docker-image-php-fpm.yml`,
+whose matrix is large enough that it builds only on `master`.)
 
 Every workflow has the same two-stage shape:
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,12 @@ owner automatically (the namespace is derived from `github.repository_owner`).
 | `opensearch` | `2.9`–`2.13`, `2.19`, `3.1`–`3.3` + newer (auto) |
 | `rabbitmq` | `3.7`–`3.13`, `4.1` + newer (auto) |
 | `magepack` | `2.3`–`2.11` |
-| `mailhog`, `dnsmasq`, `startpage` | single image (no version matrix) |
+| `mailhog`, `dnsmasq`, `startpage` | `latest` (single image, no version matrix) |
 
-Image tags mirror the upstream version string. No `latest` tag is created for the
-service images. "**+ newer (auto)**" means the workflow **discovers** new upstream
-releases and starts building them on its own — see
+Image tags mirror the upstream version string. The **version-matrix** images do not
+get a `latest` tag; the single-image utilities (`mailhog`, `dnsmasq`, `startpage`)
+are published only as `:latest`. "**+ newer (auto)**" means the workflow
+**discovers** new upstream releases and starts building them on its own — see
 [Adding or changing a version](#adding-or-changing-a-version).
 
 ## How builds work

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -16,8 +16,13 @@ ENV GROUP_ID        20
 ENV OSTYPE          darwin220
 ENV ADD_PHP_EXT     ""
 
-# PHP Extension Installer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+# PHP Extension Installer.
+# Fetched with curl (not ADD) so a transient network blip retries instead of
+# failing the whole build. curl ships in the official php base image.
+RUN set -eux; \
+    curl -fSL --retry 5 --retry-delay 5 --retry-all-errors \
+      -o /usr/local/bin/install-php-extensions \
+      https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions
 
 # Copy mhsendmail to PHP
 COPY --from=mhs-builder /go/bin/sendmail /usr/local/bin/mhsendmail
@@ -152,11 +157,19 @@ RUN set -eux; \
         echo 'fi'; \
 	} >> /etc/bash.bashrc;
 
-# Install Oh My Zsh including the following Plugins: git, composer and n98-magerun
-RUN sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
-RUN git clone https://github.com/zsh-users/zsh-autosuggestions.git $ZSH_CUSTOM/plugins/zsh-autosuggestions \
-    && git clone https://github.com/zsh-users/zsh-syntax-highlighting.git $ZSH_CUSTOM/plugins/zsh-syntax-highlighting \
-    && sed -i 's/plugins=(git)/plugins=(git composer n98-magerun zsh-autosuggestions zsh-syntax-highlighting)/g' /root/.zshrc
+# Install Oh My Zsh including the following Plugins: git, composer and n98-magerun.
+# curl retries transient failures; the git clones retry in a loop so a flaky
+# network fetch doesn't fail the whole image build.
+RUN sh -c "$(curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+RUN set -eux; \
+    for repo in zsh-users/zsh-autosuggestions zsh-users/zsh-syntax-highlighting; do \
+      dest="$ZSH_CUSTOM/plugins/$(basename "$repo")"; \
+      n=0; until git clone "https://github.com/${repo}.git" "$dest"; do \
+        n=$((n + 1)); [ "$n" -ge 5 ] && { echo "git clone $repo failed after $n attempts"; exit 1; }; \
+        echo "git clone $repo failed, retry $n..."; sleep 10; \
+      done; \
+    done; \
+    sed -i 's/plugins=(git)/plugins=(git composer n98-magerun zsh-autosuggestions zsh-syntax-highlighting)/g' /root/.zshrc
 
 # Configure www-data user as primary php-fpm user for better local dev experience
 RUN mkdir -p /home/www-data \

--- a/php-fpm/magento1/Dockerfile
+++ b/php-fpm/magento1/Dockerfile
@@ -3,10 +3,15 @@ ARG PHP_VERSION
 FROM ${ENV_SOURCE_IMAGE}:${PHP_VERSION}
 USER root
 
-ADD https://files.magerun.net/n98-magerun.phar /usr/local/bin/n98-magerun
+# curl --retry instead of ADD so a transient download blip retries.
+RUN set -eux; \
+    curl -fSL --retry 5 --retry-delay 5 --retry-all-errors \
+      -o /usr/local/bin/n98-magerun https://files.magerun.net/n98-magerun.phar
 RUN chmod +rx /usr/local/bin/n98-magerun \
     && ln -s /usr/local/bin/n98-magerun /usr/local/bin/magerun \
     && ln -s /usr/local/bin/n98-magerun /usr/local/bin/mr
 
-ADD https://raw.githubusercontent.com/netz98/n98-magerun/master/res/autocompletion/bash/n98-magerun.phar.bash /etc/bash_completion.d/n98-magerun.phar
+RUN set -eux; \
+    curl -fSL --retry 5 --retry-delay 5 --retry-all-errors \
+      -o /etc/bash_completion.d/n98-magerun.phar https://raw.githubusercontent.com/netz98/n98-magerun/master/res/autocompletion/bash/n98-magerun.phar.bash
 RUN chmod +r /etc/bash_completion.d/n98-magerun.phar

--- a/php-fpm/magento1/Dockerfile
+++ b/php-fpm/magento1/Dockerfile
@@ -12,6 +12,7 @@ RUN chmod +rx /usr/local/bin/n98-magerun \
     && ln -s /usr/local/bin/n98-magerun /usr/local/bin/mr
 
 RUN set -eux; \
+    mkdir -p /etc/bash_completion.d; \
     curl -fSL --retry 5 --retry-delay 5 --retry-all-errors \
       -o /etc/bash_completion.d/n98-magerun.phar https://raw.githubusercontent.com/netz98/n98-magerun/master/res/autocompletion/bash/n98-magerun.phar.bash
 RUN chmod +r /etc/bash_completion.d/n98-magerun.phar

--- a/php-fpm/magento2/Dockerfile
+++ b/php-fpm/magento2/Dockerfile
@@ -46,17 +46,20 @@ RUN set -eux; \
     myloader --version
 
 # Magerun
-
-ADD https://files.magerun.net/n98-magerun2.phar /usr/local/bin/n98-magerun2
+# Downloaded with curl --retry (not ADD) so a transient files.magerun.net blip
+# retries instead of failing the build.
+RUN set -eux; \
+    curl -fSL --retry 5 --retry-delay 5 --retry-all-errors \
+      -o /usr/local/bin/n98-magerun2 https://files.magerun.net/n98-magerun2.phar
 
 # overwrite n98-magerun2 for specific version of PHP if needed
 # If PHP = 7.3
 RUN if [ "${PHP_VERSION}" = "7.3" ]; \
-    then curl https://files.magerun.net/n98-magerun2-6.1.1.phar -o /usr/local/bin/n98-magerun2; fi
+    then curl -fSL --retry 5 --retry-delay 5 --retry-all-errors https://files.magerun.net/n98-magerun2-6.1.1.phar -o /usr/local/bin/n98-magerun2; fi
 
 # If PHP < 7.3
 RUN if [ "$(printf "7.3\n${PHP_VERSION}" | sort -g | head -n1 | awk -F"." '{print $1"."$2}')" != "7.3" ]; \
-    then curl https://files.magerun.net/n98-magerun2-4.7.0.phar -o /usr/local/bin/n98-magerun2; fi
+    then curl -fSL --retry 5 --retry-delay 5 --retry-all-errors https://files.magerun.net/n98-magerun2-4.7.0.phar -o /usr/local/bin/n98-magerun2; fi
 
 RUN chmod +rx /usr/local/bin/n98-magerun2 \
     && ln -s /usr/local/bin/n98-magerun2 /usr/local/bin/n98-magerun \
@@ -65,10 +68,14 @@ RUN chmod +rx /usr/local/bin/n98-magerun2 \
     && ln -s /usr/local/bin/n98-magerun2 /usr/local/bin/mr \
     && ln -s /usr/local/bin/n98-magerun2 /usr/local/bin/n98-magerun2.phar
 
-# Magerun Auto-complete
-ADD https://raw.githubusercontent.com/netz98/n98-magerun2/master/res/autocompletion/bash/n98-magerun2.phar.bash /etc/bash_completion.d/n98-magerun2.phar
-ADD https://raw.githubusercontent.com/netz98/n98-magerun2/master/res/autocompletion/fish/n98-magerun2.phar.fish /etc/fish/completions/n98-magerun2.phar.fish
-ADD https://raw.githubusercontent.com/netz98/n98-magerun2/master/res/autocompletion/zsh/n98-magerun2.plugin.zsh /usr/share/zsh/site-functions/_n98-magerun2
+# Magerun Auto-complete (curl --retry instead of ADD for resilience)
+RUN set -eux; \
+    curl -fSL --retry 5 --retry-delay 5 --retry-all-errors \
+      -o /etc/bash_completion.d/n98-magerun2.phar https://raw.githubusercontent.com/netz98/n98-magerun2/master/res/autocompletion/bash/n98-magerun2.phar.bash; \
+    curl -fSL --retry 5 --retry-delay 5 --retry-all-errors \
+      -o /etc/fish/completions/n98-magerun2.phar.fish https://raw.githubusercontent.com/netz98/n98-magerun2/master/res/autocompletion/fish/n98-magerun2.phar.fish; \
+    curl -fSL --retry 5 --retry-delay 5 --retry-all-errors \
+      -o /usr/share/zsh/site-functions/_n98-magerun2 https://raw.githubusercontent.com/netz98/n98-magerun2/master/res/autocompletion/zsh/n98-magerun2.plugin.zsh
 
 RUN sed -i 's/\(#compdef n98-magerun2.phar\)/\1 n98-magerun2=n98-magerun2.phar n98-magerun=n98-magerun2.phar magerun2=n98-magerun2.phar magerun=n98-magerun2.phar/' /usr/share/zsh/site-functions/_n98-magerun2 \
     && sed -i 's/\(compdef _n98_magerun2 n98-magerun2.phar\)/\1 n98-magerun2=n98-magerun2.phar n98-magerun=n98-magerun2.phar magerun2=n98-magerun2.phar magerun=n98-magerun2.phar/' /usr/share/zsh/site-functions/_n98-magerun2 \
@@ -84,7 +91,10 @@ RUN sed -i 's/\(#compdef n98-magerun2.phar\)/\1 n98-magerun2=n98-magerun2.phar n
 # Mage2 TV Cache
 RUN mkdir /home/www-data/mage-cache-clean \
     && cd /home/www-data/mage-cache-clean \
-    && composer2 require mage2tv/magento-cache-clean \
+    && ( n=0; until composer2 require mage2tv/magento-cache-clean; do \
+           n=$((n + 1)); [ "$n" -ge 5 ] && { echo "composer require failed after $n attempts"; exit 1; }; \
+           echo "composer require failed, retry $n..."; sleep 10; \
+         done ) \
     && ln -s /home/www-data/mage-cache-clean/vendor/bin/cache-clean.js /usr/local/bin/cache-clean.js \
     && ln -s /home/www-data/mage-cache-clean/vendor/bin/cache-clean.js /usr/local/bin/cache-clean \
     && chmod +rx -R /home/www-data/mage-cache-clean

--- a/php-fpm/magento2/Dockerfile
+++ b/php-fpm/magento2/Dockerfile
@@ -68,8 +68,10 @@ RUN chmod +rx /usr/local/bin/n98-magerun2 \
     && ln -s /usr/local/bin/n98-magerun2 /usr/local/bin/mr \
     && ln -s /usr/local/bin/n98-magerun2 /usr/local/bin/n98-magerun2.phar
 
-# Magerun Auto-complete (curl --retry instead of ADD for resilience)
+# Magerun Auto-complete (curl --retry instead of ADD for resilience).
+# Unlike ADD, curl won't create missing parent dirs, so create them first.
 RUN set -eux; \
+    mkdir -p /etc/bash_completion.d /etc/fish/completions /usr/share/zsh/site-functions; \
     curl -fSL --retry 5 --retry-delay 5 --retry-all-errors \
       -o /etc/bash_completion.d/n98-magerun2.phar https://raw.githubusercontent.com/netz98/n98-magerun2/master/res/autocompletion/bash/n98-magerun2.phar.bash; \
     curl -fSL --retry 5 --retry-delay 5 --retry-all-errors \

--- a/php-fpm/node/Dockerfile
+++ b/php-fpm/node/Dockerfile
@@ -4,7 +4,12 @@ ARG OS_RELEASE
 ARG NODE_VERSION
 
 FROM node:${NODE_VERSION}-${OS_RELEASE:-bullseye} AS node
-RUN npm install -g grunt-cli gulp
+# Retry the global install so a transient npm registry blip doesn't fail the build.
+RUN set -eux; \
+    n=0; until npm install -g grunt-cli gulp; do \
+      n=$((n + 1)); [ "$n" -ge 5 ] && { echo "npm install failed after $n attempts"; exit 1; }; \
+      echo "npm install failed, retry $n..."; sleep 10; \
+    done
 RUN mv /opt/yarn* /opt/yarn
 
 FROM ${ENV_SOURCE_IMAGE}:${PHP_VERSION}

--- a/php-fpm/wordpress/Dockerfile
+++ b/php-fpm/wordpress/Dockerfile
@@ -3,8 +3,10 @@ ARG PHP_VERSION
 FROM ${ENV_SOURCE_IMAGE}:${PHP_VERSION}
 USER root
 
-# Wordpress Cli tool
-ADD https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar /usr/local/bin/wp-cli
+# Wordpress Cli tool (curl --retry instead of ADD so a transient blip retries)
+RUN set -eux; \
+    curl -fSL --retry 5 --retry-delay 5 --retry-all-errors \
+      -o /usr/local/bin/wp-cli https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
 
 # Create wp alias for wp-cli
 RUN chmod +rx /usr/local/bin/wp-cli \


### PR DESCRIPTION
Robustness (fixes one-flaky-build-blocks-everything):
- php-fpm merge-* jobs run on partial success (!cancelled()) and publish only versions with both arch digests, skipping incomplete ones instead of failing the whole run — a single flaky combo no longer blocks every php-fpm tag.
- Fix EOL-flag clobber in full-generator.php (PHP EOL was overwritten by Node EOL, so e.g. 7.3+node21 was wrongly non-continue-on-error).
- Retry in-Dockerfile downloads (install-php-extensions, magerun, wp-cli, composer require, npm install, git clone) instead of single-attempt ADD/RUN.
- Remove dead Docker Hub login steps across all workflows.

Dynamic discovery (floor + pinned override + deny):
- constants.php is now the php-fpm version policy (MIN/PIN/DENY + OS/EOL maps); generators read discovered versions from env, falling back to the pinned list.
- php-fpm gains a crane `discover` job feeding the generators (native-arm per-arch + merge design preserved; no QEMU).
- All simple services (redis, mongo, nginx, rabbitmq, mariadb, mysql, elasticsearch, opensearch, varnish, dragonfly) gain a discover job: build the pinned list plus any upstream version newer than the newest pin.
- Add optional mirror-base-images.yml (Docker Hub -> GHCR base-images) with soft fallback; php base layer consumes it when present.

Docs: rewrite README.md + CLAUDE.md (pipeline shape, robustness model, and how to add/pin/exclude a version).